### PR TITLE
Refactor + add clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,204 @@
+---
+Language: Cpp
+BasedOnStyle: WebKit
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: false
+AlignConsecutiveBitFields:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: false
+AlignConsecutiveDeclarations:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: false
+AlignConsecutiveMacros:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: false
+AlignConsecutiveShortCaseStatements:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCaseColons: false
+AlignEscapedNewlines: DontAlign
+AlignOperands: DontAlign
+AlignTrailingComments:
+  Kind: Never
+  OverEmptyLines: 0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: None
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+# AttributeMacros:
+#   - __capability
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterExternBlock: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: false
+  AfterStruct: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: true
+  BeforeWhile: true
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAfterAttributes: Never
+BreakAfterJavaFieldAnnotations: false
+BreakArrays: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Allman
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: AfterColon
+BreakStringLiterals: false
+ColumnLimit: 100
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex: '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority: 2
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: '^(<|"(gtest|gmock|isl|json)/)'
+    Priority: 3
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: '.*'
+    Priority: 1
+    SortPriority: 0
+    CaseSensitive: false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+InsertBraces: false
+InsertNewlineAtEOF: true
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary: 0
+  BinaryMinDigits: 0
+  Decimal: 0
+  DecimalMinDigits: 0
+  Hex: 0
+  HexMinDigits: 0
+KeepEmptyLinesAtTheStartOfBlocks: true
+KeepEmptyLinesAtEOF: false
+LambdaBodyIndentation: Signature
+LineEnding: DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 4
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: NextLineOnly
+PenaltyBreakBeforeFirstCallParameter: 50
+PenaltyExcessCharacter: 4
+PenaltyReturnTypeOnItsOwnLine: 10000
+PointerAlignment: Left
+PPIndentWidth: -1
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
+ReflowComments: true
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes: CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros: true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: true
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: Never
+SpacesInContainerLiterals: false
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
+SpacesInParens: Never
+SpacesInParensOptions:
+  InCStyleCasts: false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other: false
+SpacesInSquareBrackets: false
+Standard: Latest
+TabWidth: 4
+UseTab: Never

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,12 @@ set(SRCS
     "src/sirius/bitboard.h"
     "src/sirius/board.cpp"
     "src/sirius/board.h"
+    "src/sirius/castling.h"
+    "src/sirius/cuckoo.cpp"
+    "src/sirius/cuckoo.h"
     "src/sirius/defs.h"
+    "src/sirius/movegen.cpp"
+    "src/sirius/movegen.h"
     "src/sirius/zobrist.h"
 
     "src/dataset.cpp"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,70 @@
+{
+    "version": 4,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 24,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "ninja-clang-x86-64-v1",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/x86-64-v1",
+            "cacheVariables": {
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_CXX_FLAGS_INIT": "-Wall",
+                "CMAKE_CXX_FLAGS_RELEASE_INIT": "-march=x86-64 -flto",
+                "SIRIUS_EXE_EXTENSION" : "x86-64-v1"
+            }
+        },
+        {
+            "name": "ninja-clang-x86-64-v2",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/x86-64-v2",
+            "cacheVariables": {
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_CXX_FLAGS_INIT": "-Wall",
+                "CMAKE_CXX_FLAGS_RELEASE_INIT": "-march=x86-64-v2 -flto",
+                "SIRIUS_EXE_EXTENSION" : "x86-64-v2"
+            }
+        },
+        {
+            "name": "ninja-clang-x86-64-v3",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/x86-64-v3",
+            "cacheVariables": {
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_CXX_FLAGS_INIT": "-Wall",
+                "CMAKE_CXX_FLAGS_RELEASE_INIT": "-march=x86-64-v3 -flto",
+                "SIRIUS_EXE_EXTENSION" : "x86-64-v3"
+            }
+        },
+        {
+            "name": "ninja-clang-x86-64-v4",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/x86-64-v4",
+            "cacheVariables": {
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_CXX_FLAGS_INIT": "-Wall",
+                "CMAKE_CXX_FLAGS_RELEASE_INIT": "-march=x86-64-v4 -flto",
+                "SIRIUS_EXE_EXTENSION" : "x86-64-v4"
+            }
+        },
+        {
+            "name": "ninja-clang-native",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/native",
+            "cacheVariables": {
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_CXX_FLAGS_INIT": "-Wall",
+                "CMAKE_CXX_FLAGS_RELEASE_INIT": "-march=native -flto",
+                "SIRIUS_EXE_EXTENSION" : "native"
+            }
+        }
+    ]
+}

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -4,15 +4,11 @@
 
 #include <string>
 
-
-constexpr struct {const char* str; double wdl;} wdls[] = {
-    {"1-0", 1.0},
-    {"0-1", 0.0},
-    {"1/2-1/2", 0.5},
-    {"1.0", 1.0},
-    {"0.0", 0.0},
-    {"0.5", 0.5}
-};
+constexpr struct
+{
+    const char* str;
+    double wdl;
+} wdls[] = {{"1-0", 1.0}, {"0-1", 0.0}, {"1/2-1/2", 0.5}, {"1.0", 1.0}, {"0.0", 0.0}, {"0.5", 0.5}};
 
 Dataset loadDataset(std::ifstream& file)
 {
@@ -28,7 +24,7 @@ Dataset loadDataset(std::ifstream& file)
         {
             if (line.find(wdl.str) != std::string::npos)
             {
-                wdlResult  = wdl.wdl;
+                wdlResult = wdl.wdl;
                 break;
             }
         }
@@ -59,11 +55,9 @@ Dataset loadDataset(std::ifstream& file)
         pos.coeffBegin = coeffBegin;
         pos.coeffEnd = coeffEnd;
         pos.wdl = wdlResult;
-        pos.phase =
-            4 * board.pieces(PieceType::QUEEN).popcount() +
-            2 * board.pieces(PieceType::ROOK).popcount() +
-            board.pieces(PieceType::BISHOP).popcount() +
-            board.pieces(PieceType::KNIGHT).popcount();
+        pos.phase = 4 * board.pieces(PieceType::QUEEN).popcount()
+            + 2 * board.pieces(PieceType::ROOK).popcount()
+            + board.pieces(PieceType::BISHOP).popcount() + board.pieces(PieceType::KNIGHT).popcount();
         pos.phase /= 24.0;
         pos.egScale = egScale;
 

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <array>
 #include <fstream>
 #include <span>
 #include <vector>
-#include <array>
 
 struct Coefficient
 {

--- a/src/eval_constants.h
+++ b/src/eval_constants.h
@@ -3,9 +3,9 @@
 // clang-format off
 #define S(mg, eg) {mg, eg}
 
-constexpr PackedScore MATERIAL[6] = {S(  61,  131), S( 286,  431), S( 306,  444), S( 386,  789), S( 745, 1618), S(0, 0)};
+constexpr ScorePair MATERIAL[6] = {S(  61,  131), S( 286,  431), S( 306,  444), S( 386,  789), S( 745, 1618), S(0, 0)};
 
-constexpr PackedScore PSQT[6][64] = {
+constexpr ScorePair PSQT[6][64] = {
     {
         S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0),
         S(  54,   79), S(  37,   90), S(  21,  101), S(  55,   77), S(  73,   61), S(  57,   76), S(  47,   95), S(  68,   77),
@@ -68,48 +68,48 @@ constexpr PackedScore PSQT[6][64] = {
     },
 };
 
-constexpr PackedScore MOBILITY[4][28] = {
+constexpr ScorePair MOBILITY[4][28] = {
     {S(  -3,  -29), S( -39,  -47), S( -18,  -16), S(  -9,    0), S(   1,    9), S(   6,   19), S(  13,   22), S(  20,   26), S(  29,   19), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0)},
     {S( -10,  -46), S( -30,  -61), S( -18,  -32), S( -11,  -14), S(  -3,   -4), S(   2,    6), S(   4,   15), S(   7,   19), S(   7,   21), S(   9,   22), S(  10,   22), S(  14,   17), S(  12,   23), S(  17,    4), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0)},
     {S( -12,  -44), S( -29,  -70), S( -14,  -53), S(  -2,  -31), S(   0,  -17), S(  -2,   -6), S(  -1,    2), S(   1,    8), S(   3,   11), S(   6,   17), S(   3,   27), S(   4,   34), S(   6,   38), S(   9,   39), S(  16,   36), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0)},
     {S(   0,    8), S( -32,  -72), S( -61, -112), S( -19, -198), S( -24,  -63), S( -16,  -11), S(  -6,  -23), S(  -4,   -5), S(  -3,   13), S(   0,   22), S(   2,   25), S(   6,   28), S(   6,   38), S(  10,   37), S(  10,   43), S(  12,   44), S(  13,   46), S(  15,   47), S(  15,   46), S(  21,   38), S(  25,   29), S(  31,   13), S(  28,   18), S(  34,   -5), S(  34,   -8), S(   9,   -7), S( -13,  -11), S(-116,   10)}
 };
 
-constexpr PackedScore THREAT_BY_PAWN[6] = {S(   4,  -20), S(  66,   28), S(  60,   60), S(  81,   24), S(  72,   -2), S(   0,    0)};
-constexpr PackedScore THREAT_BY_KNIGHT[2][6] = {
+constexpr ScorePair THREAT_BY_PAWN[6] = {S(   4,  -20), S(  66,   28), S(  60,   60), S(  81,   24), S(  72,   -2), S(   0,    0)};
+constexpr ScorePair THREAT_BY_KNIGHT[2][6] = {
     {S(   3,   28), S(  14,   36), S(  35,   43), S(  73,   13), S(  53,  -30), S(   0,    0)},
     {S(  -7,    9), S(   6,   36), S(  29,   29), S(  64,   34), S(  60,   -1), S(   0,    0)}
 };
-constexpr PackedScore THREAT_BY_BISHOP[2][6] = {
+constexpr ScorePair THREAT_BY_BISHOP[2][6] = {
     {S(  -3,   34), S(  38,   32), S( -15,   36), S(  67,   15), S(  68,   44), S(   0,    0)},
     {S(  -4,    6), S(  17,   22), S( -26,  -11), S(  44,   44), S(  47,  111), S(   0,    0)}
 };
-constexpr PackedScore THREAT_BY_ROOK[2][6] = {
+constexpr ScorePair THREAT_BY_ROOK[2][6] = {
     {S(  -2,   40), S(  15,   57), S(  25,   53), S( -13,  -28), S(  60,   13), S(   0,    0)},
     {S(  -8,    7), S(   1,   15), S(  14,    3), S( -12,  -66), S(  42,   62), S(   0,    0)}
 };
-constexpr PackedScore THREAT_BY_QUEEN[2][6] = {
+constexpr ScorePair THREAT_BY_QUEEN[2][6] = {
     {S(   6,    5), S(  23,   19), S(  10,   42), S(  14,    2), S(  10,  -56), S(  99,   54)},
     {S(  -3,   12), S(   0,    8), S(  -5,   15), S(  -3,    3), S( -15,  -74), S( 118,   53)}
 };
-constexpr PackedScore THREAT_BY_KING[6] = {S( -14,   43), S(   8,   48), S(  28,   41), S(  83,    8), S(   0,    0), S(   0,    0)};
-constexpr PackedScore KNIGHT_HIT_QUEEN = S(  10,    3);
-constexpr PackedScore BISHOP_HIT_QUEEN = S(  16,    9);
-constexpr PackedScore ROOK_HIT_QUEEN = S(  18,   -5);
-constexpr PackedScore PUSH_THREAT = S(  14,   18);
-constexpr PackedScore RESTRICTED_SQUARES = S(   2,    3);
+constexpr ScorePair THREAT_BY_KING[6] = {S( -14,   43), S(   8,   48), S(  28,   41), S(  83,    8), S(   0,    0), S(   0,    0)};
+constexpr ScorePair KNIGHT_HIT_QUEEN = S(  10,    3);
+constexpr ScorePair BISHOP_HIT_QUEEN = S(  16,    9);
+constexpr ScorePair ROOK_HIT_QUEEN = S(  18,   -5);
+constexpr ScorePair PUSH_THREAT = S(  14,   18);
+constexpr ScorePair RESTRICTED_SQUARES = S(   2,    3);
 
-constexpr PackedScore ISOLATED_PAWN[8] = {S(  -8,    6), S(  -3,  -16), S( -12,   -8), S( -10,  -16), S( -12,  -14), S(  -8,   -7), S(  -4,  -14), S( -12,    7)};
-constexpr PackedScore DOUBLED_PAWN[8] = {S(   0,  -61), S(  13,  -37), S(   0,  -27), S(  -2,  -17), S(  -5,  -12), S(  -8,  -20), S(   5,  -38), S(   6,  -71)};
-constexpr PackedScore BACKWARDS_PAWN[8] = {S(   0,    0), S(  -8,  -12), S(  -2,  -14), S(  -7,  -12), S(   1,  -18), S(  32,  -13), S(   0,    0), S(   0,    0)};
-constexpr PackedScore PAWN_PHALANX[8] = {S(   0,    0), S(   5,   -4), S(  11,   -2), S(  20,    8), S(  39,   41), S( 117,  213), S(   6,  340), S(   0,    0)};
-constexpr PackedScore DEFENDED_PAWN[8] = {S(   0,    0), S(   0,    0), S(  18,    6), S(  11,    8), S(  17,   21), S(  33,   64), S( 141,   76), S(   0,    0)};
-constexpr PackedScore CANDIDATE_PASSER[2][8] = {
+constexpr ScorePair ISOLATED_PAWN[8] = {S(  -8,    6), S(  -3,  -16), S( -12,   -8), S( -10,  -16), S( -12,  -14), S(  -8,   -7), S(  -4,  -14), S( -12,    7)};
+constexpr ScorePair DOUBLED_PAWN[8] = {S(   0,  -61), S(  13,  -37), S(   0,  -27), S(  -2,  -17), S(  -5,  -12), S(  -8,  -20), S(   5,  -38), S(   6,  -71)};
+constexpr ScorePair BACKWARDS_PAWN[8] = {S(   0,    0), S(  -8,  -12), S(  -2,  -14), S(  -7,  -12), S(   1,  -18), S(  32,  -13), S(   0,    0), S(   0,    0)};
+constexpr ScorePair PAWN_PHALANX[8] = {S(   0,    0), S(   5,   -4), S(  11,   -2), S(  20,    8), S(  39,   41), S( 117,  213), S(   6,  340), S(   0,    0)};
+constexpr ScorePair DEFENDED_PAWN[8] = {S(   0,    0), S(   0,    0), S(  18,    6), S(  11,    8), S(  17,   21), S(  33,   64), S( 141,   76), S(   0,    0)};
+constexpr ScorePair CANDIDATE_PASSER[2][8] = {
     {S(   0,    0), S( -31,  -17), S( -18,   -7), S(   0,   26), S(  25,   52), S(  65,  114), S(   0,    0), S(   0,    0)},
     {S(   0,    0), S( -17,  -10), S(  -8,   14), S(  -4,   28), S(  18,   41), S(  26,  181), S(   0,    0), S(   0,    0)}
 };
 
-constexpr PackedScore PASSED_PAWN[2][2][8] = {
+constexpr ScorePair PASSED_PAWN[2][2][8] = {
     {
         {S(   0,    0), S(   0,    0), S(   0,    0), S( -36,  -41), S( -16,   22), S(  11,  159), S(  67,  218), S(   0,    0)},
         {S(   0,    0), S(   0,    0), S(   0,    0), S( -22,  -53), S(   3,  -20), S(  37,   41), S(  70,   25), S(   0,    0)}
@@ -119,10 +119,10 @@ constexpr PackedScore PASSED_PAWN[2][2][8] = {
         {S(   0,    0), S(   0,    0), S(   0,    0), S( -30,  -56), S(  -7,  -24), S(  16,   19), S(  -9,  -11), S(   0,    0)}
     }
 };
-constexpr PackedScore OUR_PASSER_PROXIMITY[8] = {S(  79,   98), S(  71,  100), S(  46,   72), S(   6,   58), S(   5,   38), S(   7,   25), S(  12,   17), S(  -8,   24)};
-constexpr PackedScore THEIR_PASSER_PROXIMITY[8] = {S( -44,  -10), S(  -2,    3), S(  25,    0), S(  20,   31), S(  14,   64), S(  18,   78), S(  25,   80), S(  30,   69)};
+constexpr ScorePair OUR_PASSER_PROXIMITY[8] = {S(  79,   98), S(  71,  100), S(  46,   72), S(   6,   58), S(   5,   38), S(   7,   25), S(  12,   17), S(  -8,   24)};
+constexpr ScorePair THEIR_PASSER_PROXIMITY[8] = {S( -44,  -10), S(  -2,    3), S(  25,    0), S(  20,   31), S(  14,   64), S(  18,   78), S(  25,   80), S(  30,   69)};
 
-constexpr PackedScore PAWN_STORM[2][4][8] = {
+constexpr ScorePair PAWN_STORM[2][4][8] = {
     {
         {S(  40,   36), S(-110,  -51), S( -40,  -35), S(  59,    1), S(  27,   21), S(  -1,   30), S( -10,   30), S(   0,    0)},
         {S(  32,    6), S(  43, -124), S(  92,  -83), S(  58,  -20), S(  16,   -2), S( -21,    8), S(   4,    6), S(   0,    0)},
@@ -136,41 +136,41 @@ constexpr PackedScore PAWN_STORM[2][4][8] = {
         {S(   0,    0), S(   0,    0), S(  87,   17), S(  16,   25), S( -25,   25), S( -24,   22), S(  -3,   17), S(   0,    0)}
     }
 };
-constexpr PackedScore PAWN_SHIELD[4][8] = {
+constexpr ScorePair PAWN_SHIELD[4][8] = {
     {S(  46,   36), S( -20,   51), S( -12,   41), S(  39,   30), S(  44,   16), S( -27,   -2), S( -67,  -19), S(   0,    0)},
     {S(  49,    9), S( -24,   19), S(   9,    7), S(  53,   -1), S(  43,  -16), S(  14,  -20), S( -42,  -32), S(   0,    0)},
     {S(  22,   -3), S(  15,  118), S(  12,   -2), S(  34,  -22), S(  23,  -20), S(  -6,  -26), S( -59,  -42), S(   0,    0)},
     {S(  14,   16), S(   2,   12), S(   1,   10), S(  27,    4), S(  33,    1), S(   8,    5), S( -84,    7), S(   0,    0)}
 };
-constexpr PackedScore SAFE_KNIGHT_CHECK = S( 109,    7);
-constexpr PackedScore SAFE_BISHOP_CHECK = S(  71,   18);
-constexpr PackedScore SAFE_ROOK_CHECK = S( 115,   15);
-constexpr PackedScore SAFE_QUEEN_CHECK = S(  55,   26);
-constexpr PackedScore UNSAFE_KNIGHT_CHECK = S(  16,    2);
-constexpr PackedScore UNSAFE_BISHOP_CHECK = S(  38,   10);
-constexpr PackedScore UNSAFE_ROOK_CHECK = S(  39,    3);
-constexpr PackedScore UNSAFE_QUEEN_CHECK = S(  15,    4);
-constexpr PackedScore QUEENLESS_ATTACK = S(-145,  145);
-constexpr PackedScore KING_ATTACKER_WEIGHT[4] = {S(  56,   -4), S(  21,    0), S(  29,  -13), S(   4,   -9)};
-constexpr PackedScore KING_ATTACKS = S(   7,    0);
-constexpr PackedScore WEAK_KING_RING = S(   8,   -1);
-constexpr PackedScore KING_FLANK_ATTACKS[2] = {S(  12,   -3), S(   5,   -1)};
-constexpr PackedScore KING_FLANK_DEFENSES[2] = {S(  -7,    0), S(  -8,    3)};
-constexpr PackedScore SAFETY_OFFSET = S(  78,  207);
+constexpr ScorePair SAFE_KNIGHT_CHECK = S( 109,    7);
+constexpr ScorePair SAFE_BISHOP_CHECK = S(  71,   18);
+constexpr ScorePair SAFE_ROOK_CHECK = S( 115,   15);
+constexpr ScorePair SAFE_QUEEN_CHECK = S(  55,   26);
+constexpr ScorePair UNSAFE_KNIGHT_CHECK = S(  16,    2);
+constexpr ScorePair UNSAFE_BISHOP_CHECK = S(  38,   10);
+constexpr ScorePair UNSAFE_ROOK_CHECK = S(  39,    3);
+constexpr ScorePair UNSAFE_QUEEN_CHECK = S(  15,    4);
+constexpr ScorePair QUEENLESS_ATTACK = S(-145,  145);
+constexpr ScorePair KING_ATTACKER_WEIGHT[4] = {S(  56,   -4), S(  21,    0), S(  29,  -13), S(   4,   -9)};
+constexpr ScorePair KING_ATTACKS = S(   7,    0);
+constexpr ScorePair WEAK_KING_RING = S(   8,   -1);
+constexpr ScorePair KING_FLANK_ATTACKS[2] = {S(  12,   -3), S(   5,   -1)};
+constexpr ScorePair KING_FLANK_DEFENSES[2] = {S(  -7,    0), S(  -8,    3)};
+constexpr ScorePair SAFETY_OFFSET = S(  78,  207);
 
-constexpr PackedScore MINOR_BEHIND_PAWN = S(   5,   12);
-constexpr PackedScore KNIGHT_OUTPOST = S(  23,   16);
-constexpr PackedScore BISHOP_PAWNS[7] = {S(   4,   20), S(   5,   19), S(   4,   11), S(   1,    4), S(  -2,   -5), S(  -2,  -18), S(  -5,  -30)};
-constexpr PackedScore BISHOP_PAIR = S(  19,   60);
-constexpr PackedScore LONG_DIAG_BISHOP = S(  15,    8);
-constexpr PackedScore ROOK_OPEN[2] = {S(  24,    3), S(  12,    5)};
+constexpr ScorePair MINOR_BEHIND_PAWN = S(   5,   12);
+constexpr ScorePair KNIGHT_OUTPOST = S(  23,   16);
+constexpr ScorePair BISHOP_PAWNS[7] = {S(   4,   20), S(   5,   19), S(   4,   11), S(   1,    4), S(  -2,   -5), S(  -2,  -18), S(  -5,  -30)};
+constexpr ScorePair BISHOP_PAIR = S(  19,   60);
+constexpr ScorePair LONG_DIAG_BISHOP = S(  15,    8);
+constexpr ScorePair ROOK_OPEN[2] = {S(  24,    3), S(  12,    5)};
 
-constexpr PackedScore TEMPO = S(  32,   34);
+constexpr ScorePair TEMPO = S(  32,   34);
 
-constexpr PackedScore COMPLEXITY_PAWNS = S(   0,   10);
-constexpr PackedScore COMPLEXITY_PAWNS_BOTH_SIDES = S(   0,   63);
-constexpr PackedScore COMPLEXITY_PAWN_ENDGAME = S(   0,   80);
-constexpr PackedScore COMPLEXITY_OFFSET = S(   0, -134);
+constexpr ScorePair COMPLEXITY_PAWNS = S(   0,   10);
+constexpr ScorePair COMPLEXITY_PAWNS_BOTH_SIDES = S(   0,   63);
+constexpr ScorePair COMPLEXITY_PAWN_ENDGAME = S(   0,   80);
+constexpr ScorePair COMPLEXITY_OFFSET = S(   0, -134);
 
 #undef S
 // clang-format on

--- a/src/eval_constants.h
+++ b/src/eval_constants.h
@@ -1,5 +1,6 @@
 #include "sirius/defs.h"
 
+// clang-format off
 #define S(mg, eg) {mg, eg}
 
 constexpr PackedScore MATERIAL[6] = {S(  61,  131), S( 286,  431), S( 306,  444), S( 386,  789), S( 745, 1618), S(0, 0)};
@@ -172,3 +173,4 @@ constexpr PackedScore COMPLEXITY_PAWN_ENDGAME = S(   0,   80);
 constexpr PackedScore COMPLEXITY_OFFSET = S(   0, -134);
 
 #undef S
+// clang-format on

--- a/src/eval_fn.cpp
+++ b/src/eval_fn.cpp
@@ -185,9 +185,6 @@ ScorePair evaluatePieces(const Board& board, EvalData& evalData, Trace& trace)
     constexpr Color them = ~us;
     constexpr Bitboard CENTER_SQUARES = (RANK_4_BB | RANK_5_BB) & (FILE_D_BB | FILE_E_BB);
 
-    Bitboard ourPawns = board.pieces(us, PAWN);
-    Bitboard theirPawns = board.pieces(them, PAWN);
-
     ScorePair eval{0, 0};
     Bitboard pieces = board.pieces(us, piece);
     if constexpr (piece == BISHOP)
@@ -204,8 +201,6 @@ ScorePair evaluatePieces(const Board& board, EvalData& evalData, Trace& trace)
         occupancy ^= board.pieces(us, ROOK) | board.pieces(us, QUEEN);
     else if constexpr (piece == QUEEN)
         occupancy ^= board.pieces(us, BISHOP) | board.pieces(us, ROOK);
-
-    Bitboard outpostSquares = RANK_4_BB | RANK_5_BB | (us == WHITE ? RANK_6_BB : RANK_3_BB);
 
     while (pieces.any())
     {

--- a/src/eval_fn.cpp
+++ b/src/eval_fn.cpp
@@ -1295,6 +1295,19 @@ EvalParams extractMaterial(const EvalParams& params)
             auto avg = avgValue(rebalanced, TRACE_OFFSET(psqt[pce]), TRACE_SIZE(psqt[pce]));
             rebalance(avg, material[pce], rebalanced, TRACE_OFFSET(psqt[pce]), TRACE_SIZE(psqt[pce]));
         }
+
+        if (pce == 5)
+        {
+            int offset = TRACE_OFFSET(psqt[pce]);
+            for (int rank = 0; rank < 8; rank++)
+            {
+                for (int file = 4; file < 8; file++)
+                {
+                    rebalanced[offset + rank * 8 + file].mg = 0;
+                    rebalanced[offset + rank * 8 + file].eg = 0;
+                }
+            }
+        }
     }
 
     // mobility

--- a/src/eval_fn.cpp
+++ b/src/eval_fn.cpp
@@ -1306,9 +1306,6 @@ EvalParams extractMaterial(const EvalParams& params)
     rebalance(avgValue(rebalanced, TRACE_OFFSET(mobility[3]), 28), material[4], rebalanced,
         TRACE_OFFSET(mobility[3]), 28);
 
-    // king attacks
-    // rebalance(avgValue(rebalanced, TRACE_OFFSET(kingAttacks), TRACE_SIZE(kingAttacks)), material[5], rebalanced, TRACE_OFFSET(kingAttacks), TRACE_SIZE(kingAttacks));
-
     // bishop pawns
     rebalance(avgValue(rebalanced, TRACE_OFFSET(bishopPawns), TRACE_SIZE(bishopPawns)), material[2],
         rebalanced, TRACE_OFFSET(bishopPawns), TRACE_SIZE(bishopPawns));

--- a/src/eval_fn.cpp
+++ b/src/eval_fn.cpp
@@ -1,9 +1,9 @@
 #include "eval_fn.h"
-#include "sirius/attacks.h"
 #include "eval_constants.h"
+#include "sirius/attacks.h"
 
-#include <sstream>
 #include <iomanip>
+#include <sstream>
 
 using TraceElem = ColorArray<int>;
 
@@ -115,7 +115,8 @@ PackedScore evaluateKnightOutposts(const Board& board, const PawnStructure& pawn
 {
     constexpr Color them = ~us;
     Bitboard outpostRanks = RANK_4_BB | RANK_5_BB | (us == Color::WHITE ? RANK_6_BB : RANK_3_BB);
-    Bitboard outposts = outpostRanks & ~pawnStructure.pawnAttackSpans[them] & pawnStructure.pawnAttacks[us];
+    Bitboard outposts =
+        outpostRanks & ~pawnStructure.pawnAttackSpans[them] & pawnStructure.pawnAttacks[us];
     TRACE_ADD(knightOutpost, (board.pieces(us, PieceType::KNIGHT) & outposts).popcount());
     return KNIGHT_OUTPOST * (board.pieces(us, PieceType::KNIGHT) & outposts).popcount();
 }
@@ -130,7 +131,8 @@ PackedScore evaluateBishopPawns(const Board& board, Trace& trace)
     {
         Square sq = bishops.poplsb();
         bool lightSquare = (Bitboard::fromSquare(sq) & LIGHT_SQUARES_BB).any();
-        Bitboard sameColorPawns = board.pieces(us, PieceType::PAWN) & (lightSquare ? LIGHT_SQUARES_BB : DARK_SQUARES_BB);
+        Bitboard sameColorPawns =
+            board.pieces(us, PieceType::PAWN) & (lightSquare ? LIGHT_SQUARES_BB : DARK_SQUARES_BB);
         TRACE_INC(bishopPawns[std::min(sameColorPawns.popcount(), 6u)]);
         eval += BISHOP_PAWNS[std::min(sameColorPawns.popcount(), 6u)];
     }
@@ -213,13 +215,17 @@ PackedScore evaluatePieces(const Board& board, EvalData& evalData, Trace& trace)
         evalData.attackedBy2[us] |= evalData.attacked[us] & attacks;
         evalData.attacked[us] |= attacks;
 
-        eval += MOBILITY[static_cast<int>(piece) - static_cast<int>(PieceType::KNIGHT)][(attacks & evalData.mobilityArea[us]).popcount()];
-        TRACE_INC(mobility[static_cast<int>(piece) - static_cast<int>(PieceType::KNIGHT)][(attacks & evalData.mobilityArea[us]).popcount()]);
+        eval += MOBILITY[static_cast<int>(piece) - static_cast<int>(PieceType::KNIGHT)]
+                        [(attacks & evalData.mobilityArea[us]).popcount()];
+        TRACE_INC(mobility[static_cast<int>(piece) - static_cast<int>(PieceType::KNIGHT)]
+                          [(attacks & evalData.mobilityArea[us]).popcount()]);
 
         if (Bitboard kingRingAtks = evalData.kingRing[them] & attacks; kingRingAtks.any())
         {
-            evalData.attackWeight[us] += KING_ATTACKER_WEIGHT[static_cast<int>(piece) - static_cast<int>(PieceType::KNIGHT)];
-            TRACE_INC(kingAttackerWeight[static_cast<int>(piece) - static_cast<int>(PieceType::KNIGHT)]);
+            evalData.attackWeight[us] +=
+                KING_ATTACKER_WEIGHT[static_cast<int>(piece) - static_cast<int>(PieceType::KNIGHT)];
+            TRACE_INC(
+                kingAttackerWeight[static_cast<int>(piece) - static_cast<int>(PieceType::KNIGHT)]);
             evalData.attackCount[us] += kingRingAtks.popcount();
         }
 
@@ -248,7 +254,8 @@ PackedScore evaluatePawns(const Board& board, PawnStructure& pawnStructure, Trac
         Square sq = pawns.poplsb();
         Square push = sq + attacks::pawnPushOffset<us>();
         Bitboard attacks = attacks::pawnAttacks(us, sq);
-        Bitboard support = attacks::passedPawnMask(them, push) & attacks::isolatedPawnMask(sq) & ourPawns;
+        Bitboard support =
+            attacks::passedPawnMask(them, push) & attacks::isolatedPawnMask(sq) & ourPawns;
         Bitboard threats = attacks & theirPawns;
         Bitboard pushThreats = attacks::pawnPushes<us>(attacks) & theirPawns;
         Bitboard defenders = attacks::pawnAttacks(them, sq) & ourPawns;
@@ -306,7 +313,8 @@ PackedScore evaluatePawns(const Board& board, PawnStructure& pawnStructure, Trac
 }
 
 template<Color us>
-PackedScore evaluatePassedPawns(const Board & board, const PawnStructure& pawnStructure, const EvalData& evalData, Trace& trace)
+PackedScore evaluatePassedPawns(
+    const Board& board, const PawnStructure& pawnStructure, const EvalData& evalData, Trace& trace)
 {
     constexpr Color them = ~us;
     Square ourKing = board.kingSq(us);
@@ -341,7 +349,8 @@ PackedScore evaluatePassedPawns(const Board & board, const PawnStructure& pawnSt
 
 PackedScore evaluatePawns(const Board& board, PawnStructure& pawnStructure, Trace& trace)
 {
-    return evaluatePawns<Color::WHITE>(board, pawnStructure, trace) - evaluatePawns<Color::BLACK>(board, pawnStructure, trace);
+    return evaluatePawns<Color::WHITE>(board, pawnStructure, trace)
+        - evaluatePawns<Color::BLACK>(board, pawnStructure, trace);
 }
 
 template<Color us>
@@ -351,10 +360,8 @@ PackedScore evaluateThreats(const Board& board, const EvalData& evalData, Trace&
 
     PackedScore eval{0, 0};
 
-    Bitboard defendedBB =
-        evalData.attackedBy2[them] |
-        evalData.attackedBy[them][PieceType::PAWN] |
-        (evalData.attacked[them] & ~evalData.attackedBy2[us]);
+    Bitboard defendedBB = evalData.attackedBy2[them] | evalData.attackedBy[them][PieceType::PAWN]
+        | (evalData.attacked[them] & ~evalData.attackedBy2[us]);
 
     Bitboard pawnThreats = evalData.attackedBy[us][PieceType::PAWN] & board.pieces(them);
     while (pawnThreats.any())
@@ -414,7 +421,9 @@ PackedScore evaluateThreats(const Board& board, const EvalData& evalData, Trace&
 
     Bitboard nonPawnEnemies = board.pieces(them) & ~board.pieces(PieceType::PAWN);
 
-    Bitboard safe = ~defendedBB | (evalData.attacked[us] & ~evalData.attackedBy[them][PieceType::PAWN] & ~evalData.attackedBy2[them]);
+    Bitboard safe = ~defendedBB
+        | (evalData.attacked[us] & ~evalData.attackedBy[them][PieceType::PAWN]
+            & ~evalData.attackedBy2[them]);
     Bitboard pushes = attacks::pawnPushes<us>(board.pieces(us, PieceType::PAWN)) & ~board.allPieces();
     pushes |= attacks::pawnPushes<us>(pushes & Bitboard::nthRank<us, RANK_3>()) & ~board.allPieces();
 
@@ -422,10 +431,11 @@ PackedScore evaluateThreats(const Board& board, const EvalData& evalData, Trace&
     eval += PUSH_THREAT * pushThreats.popcount();
     TRACE_ADD(pushThreat, pushThreats.popcount());
 
-    Bitboard restriction = evalData.attackedBy2[us] & ~evalData.attackedBy2[them] & evalData.attacked[them];
+    Bitboard restriction =
+        evalData.attackedBy2[us] & ~evalData.attackedBy2[them] & evalData.attacked[them];
     eval += RESTRICTED_SQUARES * restriction.popcount();
     TRACE_ADD(restrictedSquares, restriction.popcount());
-    
+
     Bitboard oppQueens = board.pieces(them, PieceType::QUEEN);
     if (oppQueens.one())
     {
@@ -436,15 +446,21 @@ PackedScore evaluateThreats(const Board& board, const EvalData& evalData, Trace&
 
         Bitboard targets = safe & ~board.pieces(us, PieceType::PAWN);
 
-        eval += KNIGHT_HIT_QUEEN * (targets & knightHits & evalData.attackedBy[us][PieceType::KNIGHT]).popcount();
-        TRACE_ADD(knightHitQueen, (targets & knightHits & evalData.attackedBy[us][PieceType::KNIGHT]).popcount());
+        eval += KNIGHT_HIT_QUEEN
+            * (targets & knightHits & evalData.attackedBy[us][PieceType::KNIGHT]).popcount();
+        TRACE_ADD(knightHitQueen,
+            (targets & knightHits & evalData.attackedBy[us][PieceType::KNIGHT]).popcount());
 
         targets &= evalData.attackedBy2[us];
-        eval += BISHOP_HIT_QUEEN * (targets & bishopHits & evalData.attackedBy[us][PieceType::BISHOP]).popcount();
-        TRACE_ADD(bishopHitQueen, (targets & bishopHits & evalData.attackedBy[us][PieceType::BISHOP]).popcount());
+        eval += BISHOP_HIT_QUEEN
+            * (targets & bishopHits & evalData.attackedBy[us][PieceType::BISHOP]).popcount();
+        TRACE_ADD(bishopHitQueen,
+            (targets & bishopHits & evalData.attackedBy[us][PieceType::BISHOP]).popcount());
 
-        eval += ROOK_HIT_QUEEN * (targets & rookHits & evalData.attackedBy[us][PieceType::ROOK]).popcount();
-        TRACE_ADD(rookHitQueen, (targets & rookHits & evalData.attackedBy[us][PieceType::ROOK]).popcount());
+        eval += ROOK_HIT_QUEEN
+            * (targets & rookHits & evalData.attackedBy[us][PieceType::ROOK]).popcount();
+        TRACE_ADD(rookHitQueen,
+            (targets & rookHits & evalData.attackedBy[us][PieceType::ROOK]).popcount());
     }
 
     return eval;
@@ -472,9 +488,9 @@ PackedScore evalKingPawnFile(uint32_t file, Bitboard ourPawns, Bitboard theirPaw
     }
     {
         Bitboard filePawns = theirPawns & Bitboard::fileBB(file);
-        int rank = filePawns.any() ?
-            (us == Color::WHITE ? filePawns.msb() : filePawns.lsb()).relativeRank<them>() :
-            0;
+        int rank = filePawns.any()
+            ? (us == Color::WHITE ? filePawns.msb() : filePawns.lsb()).relativeRank<them>()
+            : 0;
         eval += PAWN_SHIELD[edgeDist][rank];
         TRACE_INC(pawnShield[edgeDist][rank]);
     }
@@ -506,12 +522,15 @@ PackedScore evaluateKings(const Board& board, const EvalData& evalData, Trace& t
     Bitboard rookCheckSquares = attacks::rookAttacks(theirKing, board.allPieces());
     Bitboard bishopCheckSquares = attacks::bishopAttacks(theirKing, board.allPieces());
 
-    Bitboard knightChecks = evalData.attackedBy[us][PieceType::KNIGHT] & attacks::knightAttacks(theirKing);
+    Bitboard knightChecks =
+        evalData.attackedBy[us][PieceType::KNIGHT] & attacks::knightAttacks(theirKing);
     Bitboard bishopChecks = evalData.attackedBy[us][PieceType::BISHOP] & bishopCheckSquares;
     Bitboard rookChecks = evalData.attackedBy[us][PieceType::ROOK] & rookCheckSquares;
-    Bitboard queenChecks = evalData.attackedBy[us][PieceType::QUEEN] & (bishopCheckSquares | rookCheckSquares);
+    Bitboard queenChecks =
+        evalData.attackedBy[us][PieceType::QUEEN] & (bishopCheckSquares | rookCheckSquares);
 
-    Bitboard weak = ~evalData.attacked[them] | (~evalData.attackedBy2[them] & evalData.attackedBy[them][PieceType::KING]);
+    Bitboard weak = ~evalData.attacked[them]
+        | (~evalData.attackedBy2[them] & evalData.attackedBy[them][PieceType::KING]);
     Bitboard safe = ~board.pieces(us) & (~evalData.attacked[them] | (weak & evalData.attackedBy2[us]));
 
     TRACE_ADD(safeKnightCheck, (knightChecks & safe).popcount());
@@ -557,9 +576,11 @@ PackedScore evaluateKings(const Board& board, const EvalData& evalData, Trace& t
     Bitboard flankDefenses = evalData.kingFlank[them] & evalData.attacked[them];
     Bitboard flankDefenses2 = evalData.kingFlank[them] & evalData.attackedBy2[them];
 
-    eval += flankAttacks.popcount() * KING_FLANK_ATTACKS[0] + flankAttacks2.popcount() * KING_FLANK_ATTACKS[1];
-    eval += flankDefenses.popcount() * KING_FLANK_DEFENSES[0] + flankDefenses2.popcount() * KING_FLANK_DEFENSES[1];
-    
+    eval += flankAttacks.popcount() * KING_FLANK_ATTACKS[0]
+        + flankAttacks2.popcount() * KING_FLANK_ATTACKS[1];
+    eval += flankDefenses.popcount() * KING_FLANK_DEFENSES[0]
+        + flankDefenses2.popcount() * KING_FLANK_DEFENSES[1];
+
     TRACE_ADD(kingFlankAttacks[0], flankAttacks.popcount());
     TRACE_ADD(kingFlankAttacks[1], flankAttacks2.popcount());
     TRACE_ADD(kingFlankDefenses[0], flankDefenses.popcount());
@@ -571,7 +592,8 @@ PackedScore evaluateKings(const Board& board, const EvalData& evalData, Trace& t
     return safety;
 }
 
-PackedScore evaluateComplexity(const Board& board, const PawnStructure& pawnStructure, PackedScore eval, Trace& trace)
+PackedScore evaluateComplexity(
+    const Board& board, const PawnStructure& pawnStructure, PackedScore eval, Trace& trace)
 {
     constexpr Bitboard KING_SIDE = FILE_A_BB | FILE_B_BB | FILE_C_BB | FILE_D_BB;
     constexpr Bitboard QUEEN_SIDE = ~KING_SIDE;
@@ -584,11 +606,9 @@ PackedScore evaluateComplexity(const Board& board, const PawnStructure& pawnStru
     trace.complexityPawnEndgame[Color::WHITE] += pawnEndgame;
     trace.complexityOffset[Color::WHITE] = 1;
 
-    PackedScore complexity =
-        COMPLEXITY_PAWNS * pawns.popcount() +
-        COMPLEXITY_PAWNS_BOTH_SIDES * pawnsBothSides +
-        COMPLEXITY_PAWN_ENDGAME * pawnEndgame +
-        COMPLEXITY_OFFSET;
+    PackedScore complexity = COMPLEXITY_PAWNS * pawns.popcount()
+        + COMPLEXITY_PAWNS_BOTH_SIDES * pawnsBothSides + COMPLEXITY_PAWN_ENDGAME * pawnEndgame
+        + COMPLEXITY_OFFSET;
 
     int egSign = (eval.eg() > 0) - (eval.eg() < 0);
 
@@ -605,14 +625,16 @@ void initEvalData(const Board& board, EvalData& evalData, const PawnStructure& p
     Bitboard blockedPawns = ourPawns & attacks::pawnPushes<them>(board.allPieces());
     Square ourKing = board.kingSq(us);
 
-    evalData.mobilityArea[us] = ~pawnStructure.pawnAttacks[them] & ~Bitboard::fromSquare(ourKing) & ~blockedPawns;
+    evalData.mobilityArea[us] =
+        ~pawnStructure.pawnAttacks[them] & ~Bitboard::fromSquare(ourKing) & ~blockedPawns;
     evalData.attacked[us] = evalData.attackedBy[us][PieceType::PAWN] = pawnStructure.pawnAttacks[us];
 
     Bitboard ourKingAtks = attacks::kingAttacks(ourKing);
     evalData.attackedBy[us][PieceType::KING] = ourKingAtks;
     evalData.attackedBy2[us] = evalData.attacked[us] & ourKingAtks;
     evalData.attacked[us] |= ourKingAtks;
-    evalData.kingRing[us] = (ourKingAtks | attacks::pawnPushes<us>(ourKingAtks)) & ~Bitboard::fromSquare(ourKing);
+    evalData.kingRing[us] =
+        (ourKingAtks | attacks::pawnPushes<us>(ourKingAtks)) & ~Bitboard::fromSquare(ourKing);
     if (FILE_H_BB.has(ourKing))
         evalData.kingRing[us] |= evalData.kingRing[us].west();
     if (FILE_A_BB.has(ourKing))
@@ -627,7 +649,8 @@ PackedScore evaluatePsqt(const Board& board, Trace& trace)
     for (Color c : {Color::WHITE, Color::BLACK})
     {
         bool mirror = board.kingSq(c).file() >= FILE_E;
-        for (PieceType pt : {PieceType::PAWN, PieceType::KNIGHT, PieceType::BISHOP, PieceType::ROOK, PieceType::QUEEN, PieceType::KING})
+        for (PieceType pt : {PieceType::PAWN, PieceType::KNIGHT, PieceType::BISHOP, PieceType::ROOK,
+                 PieceType::QUEEN, PieceType::KING})
         {
             Bitboard pieces = board.pieces(c, pt);
             while (pieces.any())
@@ -640,7 +663,8 @@ PackedScore evaluatePsqt(const Board& board, Trace& trace)
                 if (mirror)
                     x ^= 7;
                 trace.psqt[static_cast<int>(pt)][sq.value() ^ x][c]++;
-                PackedScore d = MATERIAL[static_cast<int>(pt)] + PSQT[static_cast<int>(pt)][sq.value() ^ x];
+                PackedScore d =
+                    MATERIAL[static_cast<int>(pt)] + PSQT[static_cast<int>(pt)][sq.value() ^ x];
                 if (c == Color::WHITE)
                     eval += d;
                 else
@@ -654,7 +678,9 @@ PackedScore evaluatePsqt(const Board& board, Trace& trace)
 
 double evaluateScale(const Board& board, PackedScore eval)
 {
-    Color strongSide = eval.eg() > 0 ? Color::WHITE : eval.eg() < 0 ? Color::BLACK : board.sideToMove();
+    Color strongSide = eval.eg() > 0 ? Color::WHITE
+        : eval.eg() < 0              ? Color::BLACK
+                                     : board.sideToMove();
 
     int strongPawns = board.pieces(strongSide, PieceType::PAWN).popcount();
 
@@ -675,19 +701,29 @@ Trace getTrace(const Board& board)
 
     eval += evaluatePawns(board, pawnStructure, trace);
 
-    eval += evaluateKnightOutposts<Color::WHITE>(board, pawnStructure, trace) - evaluateKnightOutposts<Color::BLACK>(board, pawnStructure, trace);
-    eval += evaluateBishopPawns<Color::WHITE>(board, trace) - evaluateBishopPawns<Color::BLACK>(board, trace);
+    eval += evaluateKnightOutposts<Color::WHITE>(board, pawnStructure, trace)
+        - evaluateKnightOutposts<Color::BLACK>(board, pawnStructure, trace);
+    eval += evaluateBishopPawns<Color::WHITE>(board, trace)
+        - evaluateBishopPawns<Color::BLACK>(board, trace);
     eval += evaluateRookOpen<Color::WHITE>(board, trace) - evaluateRookOpen<Color::BLACK>(board, trace);
-    eval += evaluateMinorBehindPawn<Color::WHITE>(board, trace) - evaluateMinorBehindPawn<Color::BLACK>(board, trace);
+    eval += evaluateMinorBehindPawn<Color::WHITE>(board, trace)
+        - evaluateMinorBehindPawn<Color::BLACK>(board, trace);
 
-    eval += evaluatePieces<Color::WHITE, PieceType::KNIGHT>(board, evalData, trace) - evaluatePieces<Color::BLACK, PieceType::KNIGHT>(board, evalData, trace);
-    eval += evaluatePieces<Color::WHITE, PieceType::BISHOP>(board, evalData, trace) - evaluatePieces<Color::BLACK, PieceType::BISHOP>(board, evalData, trace);
-    eval += evaluatePieces<Color::WHITE, PieceType::ROOK>(board, evalData, trace) - evaluatePieces<Color::BLACK, PieceType::ROOK>(board, evalData, trace);
-    eval += evaluatePieces<Color::WHITE, PieceType::QUEEN>(board, evalData, trace) - evaluatePieces<Color::BLACK, PieceType::QUEEN>(board, evalData, trace);
+    eval += evaluatePieces<Color::WHITE, PieceType::KNIGHT>(board, evalData, trace)
+        - evaluatePieces<Color::BLACK, PieceType::KNIGHT>(board, evalData, trace);
+    eval += evaluatePieces<Color::WHITE, PieceType::BISHOP>(board, evalData, trace)
+        - evaluatePieces<Color::BLACK, PieceType::BISHOP>(board, evalData, trace);
+    eval += evaluatePieces<Color::WHITE, PieceType::ROOK>(board, evalData, trace)
+        - evaluatePieces<Color::BLACK, PieceType::ROOK>(board, evalData, trace);
+    eval += evaluatePieces<Color::WHITE, PieceType::QUEEN>(board, evalData, trace)
+        - evaluatePieces<Color::BLACK, PieceType::QUEEN>(board, evalData, trace);
 
-    eval += evaluateKings<Color::WHITE>(board, evalData, trace) - evaluateKings<Color::BLACK>(board, evalData, trace);
-    eval += evaluatePassedPawns<Color::WHITE>(board, pawnStructure, evalData, trace) - evaluatePassedPawns<Color::BLACK>(board, pawnStructure, evalData, trace);
-    eval += evaluateThreats<Color::WHITE>(board, evalData, trace) - evaluateThreats<Color::BLACK>(board, evalData, trace);
+    eval += evaluateKings<Color::WHITE>(board, evalData, trace)
+        - evaluateKings<Color::BLACK>(board, evalData, trace);
+    eval += evaluatePassedPawns<Color::WHITE>(board, pawnStructure, evalData, trace)
+        - evaluatePassedPawns<Color::BLACK>(board, pawnStructure, evalData, trace);
+    eval += evaluateThreats<Color::WHITE>(board, evalData, trace)
+        - evaluateThreats<Color::BLACK>(board, evalData, trace);
 
     eval += evaluateComplexity(board, pawnStructure, eval, trace);
 
@@ -703,7 +739,6 @@ Trace getTrace(const Board& board)
 EvalFn::EvalFn(std::vector<Coefficient>& coefficients)
     : m_Coefficients(coefficients)
 {
-
 }
 
 void EvalFn::reset()
@@ -892,8 +927,7 @@ EvalParams EvalFn::getMaterialParams()
 EvalParams EvalFn::getKParams()
 {
     constexpr PackedScore K_MATERIAL[6] = {
-        {67, 98}, {311, 409}, {330, 419}, {426, 746}, {860, 1403}, {0, 0}
-    };
+        {67, 98}, {311, 409}, {330, 419}, {426, 746}, {860, 1403}, {0, 0}};
 
     EvalParams params = getInitialParams();
     for (auto& param : params.linear)
@@ -922,7 +956,8 @@ void printSingle(PrintState& state)
     if constexpr (ALIGN_SIZE == 0)
         state.ss << "S(" << param.mg << ", " << param.eg << ')';
     else
-        state.ss << "S(" << std::setw(ALIGN_SIZE) << static_cast<int>(param.mg) << ", " << std::setw(ALIGN_SIZE) << static_cast<int>(param.eg) << ')';
+        state.ss << "S(" << std::setw(ALIGN_SIZE) << static_cast<int>(param.mg) << ", "
+                 << std::setw(ALIGN_SIZE) << static_cast<int>(param.eg) << ')';
 }
 
 template<int ALIGN_SIZE>
@@ -1241,7 +1276,8 @@ std::array<int, 2> avgValue(EvalParams& params, int offset, int size)
     return avg;
 }
 
-void rebalance(std::array<int, 2> factor, std::array<int, 2>& materialValue, EvalParams& params, int offset, int size)
+void rebalance(std::array<int, 2> factor, std::array<int, 2>& materialValue, EvalParams& params,
+    int offset, int size)
 {
     materialValue[0] += factor[0];
     materialValue[1] += factor[1];
@@ -1270,7 +1306,8 @@ EvalParams extractMaterial(const EvalParams& params)
         if (pce == 0)
         {
             auto avg = avgValue(rebalanced, TRACE_OFFSET(psqt[0]) + 24, TRACE_SIZE(psqt[0]) - 32);
-            rebalance(avg, material[pce], rebalanced, TRACE_OFFSET(psqt[0]) + 8, TRACE_SIZE(psqt[0]) - 16);
+            rebalance(avg, material[pce], rebalanced, TRACE_OFFSET(psqt[0]) + 8,
+                TRACE_SIZE(psqt[0]) - 16);
         }
         else
         {
@@ -1280,21 +1317,27 @@ EvalParams extractMaterial(const EvalParams& params)
     }
 
     // mobility
-    rebalance(avgValue(rebalanced, TRACE_OFFSET(mobility[0]), 9), material[1], rebalanced, TRACE_OFFSET(mobility[0]), 9);
-    rebalance(avgValue(rebalanced, TRACE_OFFSET(mobility[1]), 14), material[2], rebalanced, TRACE_OFFSET(mobility[1]), 14);
-    rebalance(avgValue(rebalanced, TRACE_OFFSET(mobility[2]), 15), material[3], rebalanced, TRACE_OFFSET(mobility[2]), 15);
-    rebalance(avgValue(rebalanced, TRACE_OFFSET(mobility[3]), 28), material[4], rebalanced, TRACE_OFFSET(mobility[3]), 28);
+    rebalance(avgValue(rebalanced, TRACE_OFFSET(mobility[0]), 9), material[1], rebalanced,
+        TRACE_OFFSET(mobility[0]), 9);
+    rebalance(avgValue(rebalanced, TRACE_OFFSET(mobility[1]), 14), material[2], rebalanced,
+        TRACE_OFFSET(mobility[1]), 14);
+    rebalance(avgValue(rebalanced, TRACE_OFFSET(mobility[2]), 15), material[3], rebalanced,
+        TRACE_OFFSET(mobility[2]), 15);
+    rebalance(avgValue(rebalanced, TRACE_OFFSET(mobility[3]), 28), material[4], rebalanced,
+        TRACE_OFFSET(mobility[3]), 28);
 
     // king attacks
     // rebalance(avgValue(rebalanced, TRACE_OFFSET(kingAttacks), TRACE_SIZE(kingAttacks)), material[5], rebalanced, TRACE_OFFSET(kingAttacks), TRACE_SIZE(kingAttacks));
 
     // bishop pawns
-    rebalance(avgValue(rebalanced, TRACE_OFFSET(bishopPawns), TRACE_SIZE(bishopPawns)), material[2], rebalanced, TRACE_OFFSET(bishopPawns), TRACE_SIZE(bishopPawns));
+    rebalance(avgValue(rebalanced, TRACE_OFFSET(bishopPawns), TRACE_SIZE(bishopPawns)), material[2],
+        rebalanced, TRACE_OFFSET(bishopPawns), TRACE_SIZE(bishopPawns));
 
     EvalParams extracted;
     for (int i = 0; i < 5; i++)
     {
-        extracted.linear.push_back(EvalParam{ParamType::NORMAL, static_cast<double>(material[i][0]), static_cast<double>(material[i][1])});
+        extracted.linear.push_back(EvalParam{ParamType::NORMAL, static_cast<double>(material[i][0]),
+            static_cast<double>(material[i][1])});
     }
     extracted.linear.insert(extracted.linear.end(), rebalanced.linear.begin(), rebalanced.linear.end());
     return extracted;

--- a/src/eval_fn.h
+++ b/src/eval_fn.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include "dataset.h"
-#include "tune.h"
 #include "sirius/board.h"
+#include "tune.h"
 #include <algorithm>
+
 
 class EvalFn
 {
@@ -17,14 +18,16 @@ public:
     static EvalParams getKParams();
     static void printEvalParams(const EvalParams& params, std::ostream& os);
     static void printEvalParamsExtracted(const EvalParams& params, std::ostream& os);
+
 private:
     template<typename T>
     void addCoefficient(const T& trace, ParamType type)
     {
-        if ((type == ParamType::NORMAL && trace[0] - trace[1] != 0) ||
-            (type == ParamType::COMPLEXITY && trace[0] != 0) ||
-            (type == ParamType::SAFETY && trace[0] != 0 || trace[1] != 0))
-            m_Coefficients.push_back({static_cast<int16_t>(m_TraceIdx), static_cast<int16_t>(trace[0]), static_cast<int16_t>(trace[1])});
+        if ((type == ParamType::NORMAL && trace[0] - trace[1] != 0)
+            || (type == ParamType::COMPLEXITY && trace[0] != 0)
+            || (type == ParamType::SAFETY && (trace[0] != 0 || trace[1] != 0)))
+            m_Coefficients.push_back({static_cast<int16_t>(m_TraceIdx),
+                static_cast<int16_t>(trace[0]), static_cast<int16_t>(trace[1])});
         m_TraceIdx++;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,11 @@
 #include <iostream>
 #include <string>
 
-#include "tune.h"
 #include "eval_fn.h"
 #include "sirius/attacks.h"
 #include "sirius/zobrist.h"
+#include "tune.h"
+
 
 int main()
 {

--- a/src/settings.h
+++ b/src/settings.h
@@ -8,5 +8,6 @@ constexpr int BATCH_SIZE = 16384;
 constexpr float TUNE_LR = 0.02;
 constexpr float TUNE_K = 0.0;
 
-static_assert(TUNE_MAX_EPOCHS % 100 == 0 && TUNE_MAX_EPOCHS > 0, "TUNE_MAX_EPOCHS must be divisible by 100 and greater than 0");
+static_assert(TUNE_MAX_EPOCHS % 100 == 0 && TUNE_MAX_EPOCHS > 0,
+    "TUNE_MAX_EPOCHS must be divisible by 100 and greater than 0");
 static_assert(!TUNE_FROM_ZERO || !TUNE_FROM_MATERIAL, "Cannot tune from zero and material values");

--- a/src/sirius/attacks.h
+++ b/src/sirius/attacks.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "defs.h"
 #include "bitboard.h"
+#include "defs.h"
 #include "util/multi_array.h"
 
 #include <utility>
@@ -45,8 +45,6 @@ struct AttackData
     std::array<Bitboard, 64> kingAttacks;
     std::array<Bitboard, 64> knightAttacks;
 
-    std::array<int, 64> castleRightsMasks;
-
     Magic bishopTable[64];
     Magic rookTable[64];
 
@@ -57,7 +55,7 @@ struct AttackData
 extern AttackData attackData;
 
 template<Color c>
-inline Bitboard pawnEastAttacks(Bitboard pawns)
+constexpr Bitboard pawnEastAttacks(Bitboard pawns)
 {
     if constexpr (c == Color::WHITE)
         return pawns.northEast();
@@ -66,7 +64,7 @@ inline Bitboard pawnEastAttacks(Bitboard pawns)
 }
 
 template<Color c>
-inline Bitboard pawnWestAttacks(Bitboard pawns)
+constexpr Bitboard pawnWestAttacks(Bitboard pawns)
 {
     if constexpr (c == Color::WHITE)
         return pawns.northWest();
@@ -75,13 +73,13 @@ inline Bitboard pawnWestAttacks(Bitboard pawns)
 }
 
 template<Color c>
-inline Bitboard pawnAttacks(Bitboard pawns)
+constexpr Bitboard pawnAttacks(Bitboard pawns)
 {
     return pawnWestAttacks<c>(pawns) | pawnEastAttacks<c>(pawns);
 }
 
 template<Color c>
-inline Bitboard pawnPushes(Bitboard pawns)
+constexpr Bitboard pawnPushes(Bitboard pawns)
 {
     if constexpr (c == Color::WHITE)
         return pawns.north();
@@ -90,7 +88,7 @@ inline Bitboard pawnPushes(Bitboard pawns)
 }
 
 template<Color c>
-inline Bitboard fillUp(Bitboard bb)
+constexpr Bitboard fillUp(Bitboard bb)
 {
     if constexpr (c == Color::WHITE)
     {
@@ -108,7 +106,7 @@ inline Bitboard fillUp(Bitboard bb)
     }
 }
 
-inline Bitboard fillUp(Bitboard bb, Color c)
+constexpr Bitboard fillUp(Bitboard bb, Color c)
 {
     if (c == Color::WHITE)
         return attacks::fillUp<Color::WHITE>(bb);
@@ -117,32 +115,19 @@ inline Bitboard fillUp(Bitboard bb, Color c)
 }
 
 template<Color c>
-inline constexpr int pawnPushOffset()
+constexpr int pawnPushOffset()
 {
     return c == Color::WHITE ? 8 : -8;
 }
 
-template<Color c>
-inline constexpr Bitboard kscBlockSquares()
+inline Bitboard alignedSquares(Square a, Square b)
 {
-    if constexpr (c == Color::WHITE)
-        return Bitboard(0x60);
-    else
-        return Bitboard(0x6000000000000000);
-}
-
-template<Color c>
-inline constexpr Bitboard qscBlockSquares()
-{
-    if constexpr (c == Color::WHITE)
-        return Bitboard(0xE);
-    else
-        return Bitboard(0xE00000000000000);
+    return attackData.alignedSquares[a.value()][b.value()];
 }
 
 inline bool aligned(Square a, Square b, Square c)
 {
-    return attackData.alignedSquares[a.value()][b.value()].has(c);
+    return alignedSquares(a, b).has(c);
 }
 
 inline Bitboard inBetweenSquares(Square src, Square dst)
@@ -153,11 +138,6 @@ inline Bitboard inBetweenSquares(Square src, Square dst)
 inline Bitboard moveMask(Square king, Square checker)
 {
     return attackData.moveMasks[king.value()][checker.value()];
-}
-
-inline CastlingRights castleRightsMask(Square square)
-{
-    return CastlingRights(static_cast<CastlingRights::Internal>(attackData.castleRightsMasks[square.value()]));
 }
 
 inline Bitboard passedPawnMask(Color color, Square square)
@@ -194,14 +174,16 @@ inline Bitboard bishopAttacks(Square square, Bitboard blockers)
 {
     blockers &= attackData.bishopTable[square.value()].mask;
     uint64_t index = blockers.value() * attackData.bishopTable[square.value()].magic;
-    return attackData.bishopTable[square.value()].attackData[index >> attackData.bishopTable[square.value()].shift];
+    return attackData.bishopTable[square.value()]
+        .attackData[index >> attackData.bishopTable[square.value()].shift];
 }
 
 inline Bitboard rookAttacks(Square square, Bitboard blockers)
 {
     blockers &= attackData.rookTable[square.value()].mask;
     uint64_t index = blockers.value() * attackData.rookTable[square.value()].magic;
-    return attackData.rookTable[square.value()].attackData[index >> attackData.rookTable[square.value()].shift];
+    return attackData.rookTable[square.value()]
+        .attackData[index >> attackData.rookTable[square.value()].shift];
 }
 
 inline Bitboard queenAttacks(Square square, Bitboard blockers)
@@ -209,27 +191,40 @@ inline Bitboard queenAttacks(Square square, Bitboard blockers)
     return bishopAttacks(square, blockers) | rookAttacks(square, blockers);
 }
 
+template<Color color>
+constexpr Bitboard kingRing(Square kingSq)
+{
+    Bitboard kingAtks = attacks::kingAttacks(kingSq);
+    Bitboard kingRing = kingAtks | attacks::pawnPushes<color>(kingAtks);
+    if (FILE_H_BB.has(kingSq))
+        kingRing |= kingRing.west();
+    if (FILE_A_BB.has(kingSq))
+        kingRing |= kingRing.east();
+    return kingRing & ~Bitboard::fromSquare(kingSq);
+}
+
 template<PieceType pce>
 inline Bitboard pieceAttacks(Square square, Bitboard blockers)
 {
     using enum PieceType;
-    static_assert(
-        pce == KNIGHT ||
-        pce == BISHOP ||
-        pce == ROOK ||
-        pce == QUEEN ||
-        pce == KING, "invalid piece type for attacks::pieceAttacks");
+    static_assert(pce == KNIGHT || pce == BISHOP || pce == ROOK || pce == QUEEN || pce == KING,
+        "invalid piece type for attacks::pieceAttacks");
     switch (pce)
     {
-        case KNIGHT: return knightAttacks(square);
-        case BISHOP: return bishopAttacks(square, blockers);
-        case ROOK: return rookAttacks(square, blockers);
-        case QUEEN: return queenAttacks(square, blockers);
-        case KING: return kingAttacks(square);
-            // unreachable
-        default: return Bitboard(0);
+        case KNIGHT:
+            return knightAttacks(square);
+        case BISHOP:
+            return bishopAttacks(square, blockers);
+        case ROOK:
+            return rookAttacks(square, blockers);
+        case QUEEN:
+            return queenAttacks(square, blockers);
+        case KING:
+            return kingAttacks(square);
+        // unreachable
+        default:
+            return EMPTY_BB;
     }
 }
-
 
 }

--- a/src/sirius/bitboard.h
+++ b/src/sirius/bitboard.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <cstdint>
-#include <iostream>
 #include <bit>
 #include <bitset>
+#include <cstdint>
+#include <iostream>
 
 #if defined(_MSC_VER)
 #include <intrin.h>
@@ -61,6 +61,7 @@ public:
     static constexpr Bitboard nthRank();
 
     static constexpr Bitboard fileBB(int file);
+
 private:
     uint64_t m_Value;
 };
@@ -68,9 +69,10 @@ private:
 constexpr Bitboard::Bitboard(uint64_t v)
     : m_Value(v)
 {
-
 }
 
+constexpr Bitboard EMPTY_BB = Bitboard(0);
+constexpr Bitboard ALL_BB = Bitboard(0xFFFFFFFFFFFFFFFFull);
 constexpr Bitboard FILE_A_BB = Bitboard(0x0101010101010101ull);
 constexpr Bitboard FILE_B_BB = Bitboard(0x0202020202020202ull);
 constexpr Bitboard FILE_C_BB = Bitboard(0x0404040404040404ull);
@@ -156,7 +158,6 @@ constexpr Bitboard& Bitboard::operator^=(const Bitboard& other)
     m_Value ^= other.m_Value;
     return *this;
 }
-
 
 inline uint8_t reverse(uint8_t b)
 {

--- a/src/sirius/board.h
+++ b/src/sirius/board.h
@@ -1,14 +1,15 @@
 #pragma once
 
-#include "defs.h"
 #include "bitboard.h"
-#include "zobrist.h"
-#include "util/murmur.h"
+#include "castling.h"
+#include "defs.h"
 #include "util/enum_array.h"
+#include "util/murmur.h"
+#include "zobrist.h"
 
-#include <string_view>
-#include <string>
 #include <array>
+#include <string>
+#include <string_view>
 #include <vector>
 
 struct CheckInfo
@@ -16,7 +17,6 @@ struct CheckInfo
     Bitboard checkers;
     std::array<Bitboard, 2> pinners;
     std::array<Bitboard, 2> blockers;
-
 };
 
 struct BoardState
@@ -53,9 +53,11 @@ struct BoardState
         else
         {
             nonPawnKeys[color].addPiece(pieceType, color, pos);
-            if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT || pieceType == PieceType::KING)
+            if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT
+                || pieceType == PieceType::KING)
                 minorPieceKey.addPiece(pieceType, color, pos);
-            if (pieceType == PieceType::ROOK || pieceType == PieceType::QUEEN || pieceType == PieceType::KING)
+            if (pieceType == PieceType::ROOK || pieceType == PieceType::QUEEN
+                || pieceType == PieceType::KING)
                 majorPieceKey.addPiece(pieceType, color, pos);
         }
     }
@@ -75,9 +77,11 @@ struct BoardState
         else
         {
             nonPawnKeys[color].addPiece(pieceType, color, pos);
-            if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT || pieceType == PieceType::KING)
+            if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT
+                || pieceType == PieceType::KING)
                 minorPieceKey.addPiece(pieceType, color, pos);
-            if (pieceType == PieceType::ROOK || pieceType == PieceType::QUEEN || pieceType == PieceType::KING)
+            if (pieceType == PieceType::ROOK || pieceType == PieceType::QUEEN
+                || pieceType == PieceType::KING)
                 majorPieceKey.addPiece(pieceType, color, pos);
         }
     }
@@ -98,9 +102,11 @@ struct BoardState
         else
         {
             nonPawnKeys[color].removePiece(pieceType, color, pos);
-            if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT || pieceType == PieceType::KING)
+            if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT
+                || pieceType == PieceType::KING)
                 minorPieceKey.removePiece(pieceType, color, pos);
-            if (pieceType == PieceType::ROOK || pieceType == PieceType::QUEEN || pieceType == PieceType::KING)
+            if (pieceType == PieceType::ROOK || pieceType == PieceType::QUEEN
+                || pieceType == PieceType::KING)
                 majorPieceKey.removePiece(pieceType, color, pos);
         }
     }
@@ -125,9 +131,11 @@ struct BoardState
         else
         {
             nonPawnKeys[color].movePiece(pieceType, color, src, dst);
-            if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT || pieceType == PieceType::KING)
+            if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT
+                || pieceType == PieceType::KING)
                 minorPieceKey.movePiece(pieceType, color, src, dst);
-            if (pieceType == PieceType::ROOK || pieceType == PieceType::QUEEN || pieceType == PieceType::KING)
+            if (pieceType == PieceType::ROOK || pieceType == PieceType::QUEEN
+                || pieceType == PieceType::KING)
                 majorPieceKey.movePiece(pieceType, color, src, dst);
         }
     }
@@ -146,12 +154,10 @@ public:
 
     Board();
 
-    void setToFen(const std::string_view& fen);
-    void setToEpd(const std::string_view& epd);
+    void setToFen(const std::string_view& fen, bool frc = false);
 
     std::string stringRep() const;
     std::string fenStr() const;
-    std::string epdStr() const;
 
     void makeMove(Move move);
     void makeMove(Move move, eval::EvalState& evalState);
@@ -160,6 +166,7 @@ public:
     void makeNullMove();
     void unmakeNullMove();
 
+    bool isFRC() const;
     Color sideToMove() const;
     int epSquare() const;
     int gamePly() const;
@@ -185,6 +192,7 @@ public:
     Bitboard pieces(Color color) const;
     Bitboard allPieces() const;
     Square kingSq(Color color) const;
+    Square castlingRookSq(Color color, CastleSide side) const;
 
     bool squareAttacked(Color color, Square square) const;
     bool squareAttacked(Color color, Square square, Bitboard blockers) const;
@@ -192,9 +200,7 @@ public:
     Bitboard attackersTo(Color color, Square square, Bitboard blockers) const;
     Bitboard attackersTo(Square square) const;
     Bitboard attackersTo(Square square, Bitboard blockers) const;
-
-    bool isPassedPawn(Square square) const;
-    bool isIsolatedPawn(Square square) const;
+    bool castlingBlocked(Color color, CastleSide side) const;
 
     Bitboard pinnersBlockers(Square square, Bitboard attackers, Bitboard& pinners) const;
 
@@ -206,6 +212,7 @@ public:
     bool isPseudoLegal(Move move) const;
     bool isLegal(Move move) const;
     ZKey keyAfter(Move move) const;
+
 private:
     template<bool updateEval>
     void makeMove(Move move, eval::EvalState* evalState);
@@ -220,18 +227,18 @@ private:
     void updateCheckInfo();
     void calcThreats();
     void calcRepetitions();
-    void addPiece(Square pos, Color color, PieceType pieceType/*, eval::EvalUpdates& updates*/);
-    void addPiece(Square pos, Piece piece/*, eval::EvalUpdates& updates*/);
-    void removePiece(Square pos/*, eval::EvalUpdates& updates*/);
-    void movePiece(Square src, Square dst/*, eval::EvalUpdates& updates*/);
+    void addPiece(Square pos, Color color, PieceType pieceType, eval::EvalUpdates& updates);
+    void addPiece(Square pos, Piece piece, eval::EvalUpdates& updates);
+    void removePiece(Square pos, eval::EvalUpdates& updates);
+    void movePiece(Square src, Square dst, eval::EvalUpdates& updates);
 
     int seePieceValue(PieceType type) const;
 
-    static constexpr std::array<int, 6> SEE_PIECE_VALUES = {
-        100, 450, 450, 675, 1300, 0
-    };
+    static constexpr std::array<int, 6> SEE_PIECE_VALUES = {100, 450, 450, 675, 1300, 0};
 
     std::vector<BoardState> m_States;
+    CastlingData m_CastlingData;
+    bool m_FRC;
 
     Color m_SideToMove;
 
@@ -275,7 +282,13 @@ inline bool Board::isDraw(int searchPly) const
 
 inline bool Board::is3FoldDraw(int searchPly) const
 {
-    return currState().repetitions > 1 || (currState().repetitions == 1 && currState().lastRepetition < searchPly);
+    return currState().repetitions > 1
+        || (currState().repetitions == 1 && currState().lastRepetition < searchPly);
+}
+
+inline bool Board::isFRC() const
+{
+    return m_FRC;
 }
 
 inline Color Board::sideToMove() const
@@ -382,6 +395,11 @@ inline Bitboard Board::allPieces() const
 inline Square Board::kingSq(Color color) const
 {
     return pieces(color, PieceType::KING).lsb();
+}
+
+inline Square Board::castlingRookSq(Color color, CastleSide side) const
+{
+    return m_CastlingData.rookSquare(color, side);
 }
 
 inline bool Board::squareAttacked(Color color, Square square) const

--- a/src/sirius/board.h
+++ b/src/sirius/board.h
@@ -227,10 +227,10 @@ private:
     void updateCheckInfo();
     void calcThreats();
     void calcRepetitions();
-    void addPiece(Square pos, Color color, PieceType pieceType, eval::EvalUpdates& updates);
-    void addPiece(Square pos, Piece piece, eval::EvalUpdates& updates);
-    void removePiece(Square pos, eval::EvalUpdates& updates);
-    void movePiece(Square src, Square dst, eval::EvalUpdates& updates);
+    void addPiece(Square pos, Color color, PieceType pieceType /*, eval::EvalUpdates& updates*/);
+    void addPiece(Square pos, Piece piece /*, eval::EvalUpdates& updates*/);
+    void removePiece(Square pos /*, eval::EvalUpdates& updates*/);
+    void movePiece(Square src, Square dst /*, eval::EvalUpdates& updates*/);
 
     int seePieceValue(PieceType type) const;
 

--- a/src/sirius/castling.h
+++ b/src/sirius/castling.h
@@ -1,0 +1,250 @@
+#pragma once
+
+#include "attacks.h"
+#include "defs.h"
+#include "util/enum_array.h"
+
+enum class CastleSide
+{
+    KING_SIDE,
+    QUEEN_SIDE
+};
+
+template<typename T>
+using CastleSideArray = EnumArray<T, CastleSide, 2>;
+
+struct CastlingRights
+{
+public:
+    enum class Internal : uint8_t
+    {
+        NONE = 0,
+        WHITE_KING_SIDE = 1,
+        WHITE_QUEEN_SIDE = 2,
+        BLACK_KING_SIDE = 4,
+        BLACK_QUEEN_SIDE = 8,
+        ALL = 15
+    };
+    static constexpr Internal NONE = Internal::NONE;
+    static constexpr Internal WHITE_KING_SIDE = Internal::WHITE_KING_SIDE;
+    static constexpr Internal WHITE_QUEEN_SIDE = Internal::WHITE_QUEEN_SIDE;
+    static constexpr Internal BLACK_KING_SIDE = Internal::BLACK_KING_SIDE;
+    static constexpr Internal BLACK_QUEEN_SIDE = Internal::BLACK_QUEEN_SIDE;
+    static constexpr Internal ALL = Internal::ALL;
+
+    constexpr CastlingRights();
+    constexpr CastlingRights(Internal v);
+    constexpr CastlingRights(Color color, CastleSide side);
+
+    constexpr CastlingRights& operator&=(const CastlingRights& other);
+    constexpr CastlingRights& operator|=(const CastlingRights& other);
+
+    constexpr CastlingRights operator&(const CastlingRights& other) const;
+    constexpr CastlingRights operator|(const CastlingRights& other) const;
+
+    constexpr CastlingRights operator~() const;
+
+    constexpr bool has(CastlingRights other) const;
+    constexpr bool has(Internal v) const;
+
+    constexpr int value() const;
+
+private:
+    Internal m_Value;
+};
+
+constexpr CastlingRights operator&(CastlingRights::Internal a, CastlingRights::Internal b)
+{
+    return CastlingRights(
+        static_cast<CastlingRights::Internal>(static_cast<int>(a) & static_cast<int>(b)));
+}
+
+constexpr CastlingRights operator|(CastlingRights::Internal a, CastlingRights::Internal b)
+{
+    return CastlingRights(
+        static_cast<CastlingRights::Internal>(static_cast<int>(a) | static_cast<int>(b)));
+}
+
+constexpr CastlingRights operator~(CastlingRights::Internal a)
+{
+    return static_cast<CastlingRights::Internal>(~static_cast<int>(a)) & CastlingRights::ALL;
+}
+
+constexpr CastlingRights::CastlingRights()
+    : m_Value(Internal::NONE)
+{
+}
+
+constexpr CastlingRights::CastlingRights(Internal v)
+    : m_Value(v)
+{
+}
+
+constexpr CastlingRights::CastlingRights(Color color, CastleSide side)
+    : m_Value(static_cast<Internal>(1 << (2 * static_cast<int>(color) + static_cast<int>(side))))
+{
+}
+
+constexpr CastlingRights& CastlingRights::operator&=(const CastlingRights& other)
+{
+    *this = *this & other;
+    return *this;
+}
+
+constexpr CastlingRights& CastlingRights::operator|=(const CastlingRights& other)
+{
+    *this = *this | other;
+    return *this;
+}
+
+constexpr CastlingRights CastlingRights::operator&(const CastlingRights& other) const
+{
+    return m_Value & other.m_Value;
+}
+
+constexpr CastlingRights CastlingRights::operator|(const CastlingRights& other) const
+{
+    return m_Value | other.m_Value;
+}
+
+constexpr CastlingRights CastlingRights::operator~() const
+{
+    return ~m_Value;
+}
+
+constexpr bool CastlingRights::has(CastlingRights other) const
+{
+    return static_cast<int>((m_Value & other.m_Value).m_Value) != 0;
+}
+
+constexpr bool CastlingRights::has(Internal v) const
+{
+    return static_cast<int>((m_Value & v).m_Value) != 0;
+}
+
+constexpr int CastlingRights::value() const
+{
+    return static_cast<int>(m_Value);
+}
+
+struct CastlingData
+{
+public:
+    CastlingData()
+    {
+        m_RookSquares[Color::WHITE][CastleSide::QUEEN_SIDE] = Square(0, 0);
+        m_RookSquares[Color::WHITE][CastleSide::KING_SIDE] = Square(0, 7);
+        m_KingSquares[Color::WHITE] = Square(0, 4);
+
+        m_RookSquares[Color::BLACK][CastleSide::QUEEN_SIDE] = Square(7, 0);
+        m_RookSquares[Color::BLACK][CastleSide::KING_SIDE] = Square(7, 7);
+        m_KingSquares[Color::BLACK] = Square(7, 4);
+
+        m_CastleRightsMasks.fill(CastlingRights::ALL);
+        m_BlockSquares = {};
+    }
+
+    void setKingSquares(Square whiteKing, Square blackKing)
+    {
+        m_KingSquares[Color::WHITE] = whiteKing;
+        m_KingSquares[Color::BLACK] = blackKing;
+    }
+
+    void setRookSquare(Color color, CastleSide side, Square square)
+    {
+        m_RookSquares[color][side] = square;
+    }
+
+    Square rookSquare(Color color, CastleSide side) const
+    {
+        return m_RookSquares[color][side];
+    }
+
+    Bitboard blockSquares(Color color, CastleSide side) const
+    {
+        return m_BlockSquares[color][side];
+    }
+
+    CastlingRights castleRightsMask(Square sq) const
+    {
+        return m_CastleRightsMasks[sq.value()];
+    }
+
+    void initMasks()
+    {
+        m_CastleRightsMasks.fill(CastlingRights::ALL);
+        m_CastleRightsMasks[m_RookSquares[Color::WHITE][CastleSide::KING_SIDE].value()] &=
+            ~CastlingRights::WHITE_KING_SIDE;
+        m_CastleRightsMasks[m_RookSquares[Color::WHITE][CastleSide::QUEEN_SIDE].value()] &=
+            ~CastlingRights::WHITE_QUEEN_SIDE;
+        m_CastleRightsMasks[m_KingSquares[Color::WHITE].value()] &=
+            ~(CastlingRights::WHITE_KING_SIDE | CastlingRights::WHITE_QUEEN_SIDE);
+
+        m_CastleRightsMasks[m_RookSquares[Color::BLACK][CastleSide::KING_SIDE].value()] &=
+            ~CastlingRights::BLACK_KING_SIDE;
+        m_CastleRightsMasks[m_RookSquares[Color::BLACK][CastleSide::QUEEN_SIDE].value()] &=
+            ~CastlingRights::BLACK_QUEEN_SIDE;
+        m_CastleRightsMasks[m_KingSquares[Color::BLACK].value()] &=
+            ~(CastlingRights::BLACK_KING_SIDE | CastlingRights::BLACK_QUEEN_SIDE);
+
+        const auto setBlockSquares = [&](Color c, CastleSide s)
+        {
+            Square kingDst =
+                Square(m_KingSquares[c].rank(), s == CastleSide::KING_SIDE ? FILE_G : FILE_C);
+            Square rookDst =
+                Square(m_RookSquares[c][s].rank(), s == CastleSide::KING_SIDE ? FILE_F : FILE_D);
+            m_BlockSquares[c][s] = attacks::inBetweenSquares(m_KingSquares[c], kingDst)
+                | attacks::inBetweenSquares(m_RookSquares[c][s], rookDst)
+                | Bitboard::fromSquare(kingDst) | Bitboard::fromSquare(rookDst);
+            m_BlockSquares[c][s] &=
+                ~(Bitboard::fromSquare(m_KingSquares[c]) | Bitboard::fromSquare(m_RookSquares[c][s]));
+        };
+
+        setBlockSquares(Color::WHITE, CastleSide::KING_SIDE);
+        setBlockSquares(Color::WHITE, CastleSide::QUEEN_SIDE);
+        setBlockSquares(Color::BLACK, CastleSide::KING_SIDE);
+        setBlockSquares(Color::BLACK, CastleSide::QUEEN_SIDE);
+    }
+
+private:
+    ColorArray<CastleSideArray<Square>> m_RookSquares;
+    ColorArray<Square> m_KingSquares;
+    std::array<CastlingRights, 64> m_CastleRightsMasks;
+    ColorArray<CastleSideArray<Bitboard>> m_BlockSquares;
+};
+
+constexpr Square castleKingDst(Color color, CastleSide side)
+{
+    if (color == Color::WHITE)
+    {
+        if (side == CastleSide::KING_SIDE)
+            return Square(RANK_1, FILE_G);
+        else
+            return Square(RANK_1, FILE_C);
+    }
+    else
+    {
+        if (side == CastleSide::KING_SIDE)
+            return Square(RANK_8, FILE_G);
+        else
+            return Square(RANK_8, FILE_C);
+    }
+}
+
+constexpr Square castleRookDst(Color color, CastleSide side)
+{
+    if (color == Color::WHITE)
+    {
+        if (side == CastleSide::KING_SIDE)
+            return Square(RANK_1, FILE_F);
+        else
+            return Square(RANK_1, FILE_D);
+    }
+    else
+    {
+        if (side == CastleSide::KING_SIDE)
+            return Square(RANK_8, FILE_F);
+        else
+            return Square(RANK_8, FILE_D);
+    }
+}

--- a/src/sirius/cuckoo.cpp
+++ b/src/sirius/cuckoo.cpp
@@ -1,0 +1,84 @@
+#include "cuckoo.h"
+#include "attacks.h"
+#include "zobrist.h"
+
+namespace cuckoo
+{
+
+// implementation based on Integral's https://github.com/aronpetko/integral/commit/3c09d3fcff3bb520fca58608c41ffcf7832534f6
+// and Stormphrax's https://github.com/Ciekce/Stormphrax/commit/a0ee2dac3e4fe27870a6a2ef7e1567f2345a64da
+// and Stockfish's implementation https://github.com/official-stockfish/Stockfish/blob/master/src/position.cpp
+// and the original paper https://web.archive.org/web/20201107002606/https://marcelk.net/2013-04-06/paper/upcoming-rep-v2.pdf
+
+void init()
+{
+    moves.fill(Move::nullmove());
+    keyDiffs.fill(0);
+
+    uint32_t count = 0;
+
+    using enum Color;
+    using enum PieceType;
+
+    for (PieceType pt : {KNIGHT, BISHOP, ROOK, QUEEN, KING})
+    {
+        for (Color c : {WHITE, BLACK})
+        {
+            for (int from = 0; from < 63; from++)
+            {
+                for (int to = from + 1; to < 64; to++)
+                {
+                    Bitboard pieceAttacks;
+                    switch (pt)
+                    {
+                        case PieceType::KNIGHT:
+                            pieceAttacks = attacks::knightAttacks(Square(from));
+                            break;
+                        case PieceType::BISHOP:
+                            pieceAttacks = attacks::bishopAttacks(Square(from), EMPTY_BB);
+                            break;
+                        case PieceType::ROOK:
+                            pieceAttacks = attacks::rookAttacks(Square(from), EMPTY_BB);
+                            break;
+                        case PieceType::QUEEN:
+                            pieceAttacks = attacks::queenAttacks(Square(from), EMPTY_BB);
+                            break;
+                        case PieceType::KING:
+                            pieceAttacks = attacks::kingAttacks(Square(from));
+                            break;
+                    }
+
+                    if (!pieceAttacks.has(Square(to)))
+                        continue;
+
+                    auto move = Move(Square(from), Square(to), MoveType::NONE);
+                    ZKey zkey = {};
+                    zkey.addPiece(pt, c, Square(from));
+                    zkey.addPiece(pt, c, Square(to));
+                    zkey.flipSideToMove();
+
+                    uint64_t keyDiff = zkey.value;
+
+                    uint32_t slot = H1(keyDiff);
+
+                    while (true)
+                    {
+                        std::swap(keyDiffs[slot], keyDiff);
+                        std::swap(moves[slot], move);
+
+                        if (move == Move::nullmove())
+                            break;
+
+                        slot = slot == H1(keyDiff) ? H2(keyDiff) : H1(keyDiff);
+                    }
+
+                    count++;
+                }
+            }
+        }
+    }
+
+    assert(count == 3668);
+}
+
+}

--- a/src/sirius/cuckoo.h
+++ b/src/sirius/cuckoo.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "defs.h"
+#include <array>
+
+namespace cuckoo
+{
+
+inline std::array<uint64_t, 8192> keyDiffs;
+inline std::array<Move, 8192> moves;
+
+void init();
+
+constexpr uint64_t H1(uint64_t keyDiff)
+{
+    return keyDiff % 8192;
+}
+
+constexpr uint64_t H2(uint64_t keyDiff)
+{
+    return (keyDiff >> 16) % 8192;
+}
+
+}

--- a/src/sirius/defs.h
+++ b/src/sirius/defs.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <cstdint>
-#include <iostream>
-#include <bitset>
 #include <bit>
+#include <bitset>
 #include <cassert>
 #include <cstdint>
+#include <iostream>
 
 enum class PieceType
 {
@@ -49,7 +48,6 @@ inline Color getPieceColor(Piece piece)
     return static_cast<Color>(static_cast<int>(piece) >> 3);
 }
 
-
 enum class MoveType
 {
     NONE = 0 << 12,
@@ -69,11 +67,7 @@ enum class Promotion
 inline PieceType promoPiece(Promotion promo)
 {
     static const PieceType promoPieces[4] = {
-        PieceType::KNIGHT,
-        PieceType::BISHOP,
-        PieceType::ROOK,
-        PieceType::QUEEN
-    };
+        PieceType::KNIGHT, PieceType::BISHOP, PieceType::ROOK, PieceType::QUEEN};
 
     return promoPieces[static_cast<int>(promo) >> 14];
 }
@@ -86,7 +80,6 @@ constexpr int RANK_5 = 4;
 constexpr int RANK_6 = 5;
 constexpr int RANK_7 = 6;
 constexpr int RANK_8 = 7;
-
 
 constexpr int FILE_A = 0;
 constexpr int FILE_B = 1;
@@ -104,12 +97,20 @@ public:
     explicit constexpr Square(int sq);
     constexpr Square(int rank, int file);
 
+    constexpr Square& operator+=(int other);
+    constexpr Square& operator-=(int other);
+
     constexpr bool operator==(const Square& other) const = default;
     constexpr bool operator!=(const Square& other) const = default;
     constexpr bool operator>(const Square& other) const;
     constexpr bool operator>=(const Square& other) const;
     constexpr bool operator<(const Square& other) const;
     constexpr bool operator<=(const Square& other) const;
+
+    constexpr Square& operator++();
+    constexpr Square operator++(int);
+    constexpr Square& operator--();
+    constexpr Square operator--(int);
 
     constexpr Square operator+(int other) const;
     constexpr Square operator-(int other) const;
@@ -128,6 +129,7 @@ public:
     static constexpr int chebyshev(Square a, Square b);
     static constexpr int manhattan(Square a, Square b);
     static constexpr Square average(Square a, Square b);
+
 private:
     uint8_t m_Value;
 };
@@ -141,7 +143,18 @@ constexpr Square::Square(int sq)
 constexpr Square::Square(int rank, int file)
     : m_Value(static_cast<uint8_t>(rank * 8 + file))
 {
+}
 
+constexpr Square& Square::operator+=(int other)
+{
+    *this = *this + other;
+    return *this;
+}
+
+constexpr Square& Square::operator-=(int other)
+{
+    *this = *this - other;
+    return *this;
 }
 
 constexpr bool Square::operator>(const Square& other) const
@@ -162,6 +175,32 @@ constexpr bool Square::operator<(const Square& other) const
 constexpr bool Square::operator<=(const Square& other) const
 {
     return value() <= other.value();
+}
+
+constexpr Square& Square::operator++()
+{
+    m_Value++;
+    return *this;
+}
+
+constexpr Square Square::operator++(int)
+{
+    Square tmp = *this;
+    operator++();
+    return tmp;
+}
+
+constexpr Square& Square::operator--()
+{
+    m_Value--;
+    return *this;
+}
+
+constexpr Square Square::operator--(int)
+{
+    Square tmp = *this;
+    operator--();
+    return tmp;
 }
 
 constexpr Square Square::operator+(int other) const
@@ -254,11 +293,14 @@ public:
     bool operator==(const Move& other) const = default;
     bool operator!=(const Move& other) const = default;
 
+    static constexpr Move nullmove();
+
     Square fromSq() const;
     Square toSq() const;
     int fromTo() const;
     MoveType type() const;
     Promotion promotion() const;
+
 private:
     static constexpr int TYPE_MASK = 3 << 12;
     static constexpr int PROMOTION_MASK = 3 << 14;
@@ -274,9 +316,14 @@ inline Move::Move(Square from, Square to, MoveType type)
 inline Move::Move(Square from, Square to, MoveType type, Promotion promotion)
     : m_Data(0)
 {
-    m_Data = static_cast<uint16_t>(from.value() | (to.value() << 6) | static_cast<int>(type) | static_cast<int>(promotion));
+    m_Data = static_cast<uint16_t>(
+        from.value() | (to.value() << 6) | static_cast<int>(type) | static_cast<int>(promotion));
 }
 
+constexpr Move Move::nullmove()
+{
+    return Move();
+}
 
 inline Square Move::fromSq() const
 {
@@ -317,111 +364,25 @@ inline bool isMateScore(int score)
     return std::abs(score) >= SCORE_MATE_IN_MAX;
 }
 
-struct CastlingRights
+struct ScorePair
 {
 public:
-    enum class Internal : uint8_t
-    {
-        NONE = 0,
-        WHITE_KING_SIDE = 1,
-        WHITE_QUEEN_SIDE = 2,
-        BLACK_KING_SIDE = 4,
-        BLACK_QUEEN_SIDE = 8
-    };
-    static constexpr Internal NONE = Internal::NONE;
-    static constexpr Internal WHITE_KING_SIDE = Internal::WHITE_KING_SIDE;
-    static constexpr Internal WHITE_QUEEN_SIDE = Internal::WHITE_QUEEN_SIDE;
-    static constexpr Internal BLACK_KING_SIDE = Internal::BLACK_KING_SIDE;
-    static constexpr Internal BLACK_QUEEN_SIDE = Internal::BLACK_QUEEN_SIDE;
-
-    constexpr CastlingRights();
-    constexpr CastlingRights(Internal v);
-
-    constexpr CastlingRights& operator&=(const CastlingRights& other);
-    constexpr CastlingRights& operator|=(const CastlingRights& other);
-
-    constexpr CastlingRights operator&(const CastlingRights& other) const;
-    constexpr CastlingRights operator|(const CastlingRights& other) const;
-
-    constexpr bool has(Internal v) const;
-
-    constexpr int value() const;
-private:
-    Internal m_Value;
-};
-
-constexpr CastlingRights operator&(CastlingRights::Internal a, CastlingRights::Internal b)
-{
-    return CastlingRights(static_cast<CastlingRights::Internal>(static_cast<int>(a) & static_cast<int>(b)));
-}
-
-constexpr CastlingRights operator|(CastlingRights::Internal a, CastlingRights::Internal b)
-{
-    return CastlingRights(static_cast<CastlingRights::Internal>(static_cast<int>(a) | static_cast<int>(b)));
-}
-
-constexpr CastlingRights::CastlingRights()
-    : m_Value(Internal::NONE)
-{
-
-}
-
-constexpr CastlingRights::CastlingRights(Internal v)
-    : m_Value(v)
-{
-
-}
-
-constexpr CastlingRights& CastlingRights::operator&=(const CastlingRights& other)
-{
-    *this = *this & other;
-    return *this;
-}
-
-constexpr CastlingRights& CastlingRights::operator|=(const CastlingRights& other)
-{
-    *this = *this | other;
-    return *this;
-}
-
-constexpr CastlingRights CastlingRights::operator&(const CastlingRights& other) const
-{
-    return CastlingRights(m_Value & other.m_Value);
-}
-
-constexpr CastlingRights CastlingRights::operator|(const CastlingRights& other) const
-{
-    return CastlingRights(m_Value | other.m_Value);
-}
-
-constexpr bool CastlingRights::has(Internal v) const
-{
-    return static_cast<int>((m_Value & v).m_Value) != 0;
-}
-
-constexpr int CastlingRights::value() const
-{
-    return static_cast<int>(m_Value);
-}
-
-struct PackedScore
-{
-public:
-    constexpr PackedScore() = default;
-    constexpr PackedScore(int mg, int eg);
-    constexpr PackedScore& operator+=(const PackedScore& other);
-    constexpr PackedScore& operator-=(const PackedScore& other);
+    constexpr ScorePair() = default;
+    constexpr ScorePair(int mg, int eg);
+    constexpr ScorePair& operator+=(const ScorePair& other);
+    constexpr ScorePair& operator-=(const ScorePair& other);
 
     constexpr int mg() const;
     constexpr int eg() const;
 
-    friend constexpr PackedScore operator+(const PackedScore& a, const PackedScore& b);
-    friend constexpr PackedScore operator-(const PackedScore& a, const PackedScore& b);
-    friend constexpr PackedScore operator-(const PackedScore& p);
-    friend constexpr PackedScore operator*(int a, const PackedScore& b);
-    friend constexpr PackedScore operator*(const PackedScore& a, int b);
+    friend constexpr ScorePair operator+(const ScorePair& a, const ScorePair& b);
+    friend constexpr ScorePair operator-(const ScorePair& a, const ScorePair& b);
+    friend constexpr ScorePair operator-(const ScorePair& p);
+    friend constexpr ScorePair operator*(int a, const ScorePair& b);
+    friend constexpr ScorePair operator*(const ScorePair& a, int b);
+
 private:
-    constexpr PackedScore(int value)
+    constexpr ScorePair(int value)
         : m_Value(value)
     {
     }
@@ -429,55 +390,54 @@ private:
     int32_t m_Value;
 };
 
-constexpr PackedScore::PackedScore(int mg, int eg)
+constexpr ScorePair::ScorePair(int mg, int eg)
     : m_Value((static_cast<int32_t>(static_cast<uint32_t>(eg) << 16) + mg))
 {
-
 }
 
-constexpr PackedScore& PackedScore::operator+=(const PackedScore& other)
+constexpr ScorePair& ScorePair::operator+=(const ScorePair& other)
 {
     m_Value += other.m_Value;
     return *this;
 }
 
-constexpr PackedScore& PackedScore::operator-=(const PackedScore& other)
+constexpr ScorePair& ScorePair::operator-=(const ScorePair& other)
 {
     m_Value -= other.m_Value;
     return *this;
 }
 
-constexpr int PackedScore::mg() const
+constexpr int ScorePair::mg() const
 {
     return static_cast<int16_t>(m_Value);
 }
 
-constexpr int PackedScore::eg() const
+constexpr int ScorePair::eg() const
 {
     return static_cast<int16_t>(static_cast<uint32_t>(m_Value + 0x8000) >> 16);
 }
 
-constexpr PackedScore operator+(const PackedScore& a, const PackedScore& b)
+constexpr ScorePair operator+(const ScorePair& a, const ScorePair& b)
 {
-    return PackedScore(a.m_Value + b.m_Value);
+    return ScorePair(a.m_Value + b.m_Value);
 }
 
-constexpr PackedScore operator-(const PackedScore& a, const PackedScore& b)
+constexpr ScorePair operator-(const ScorePair& a, const ScorePair& b)
 {
-    return PackedScore(a.m_Value - b.m_Value);
+    return ScorePair(a.m_Value - b.m_Value);
 }
 
-constexpr PackedScore operator-(const PackedScore& p)
+constexpr ScorePair operator-(const ScorePair& p)
 {
-    return PackedScore(-p.m_Value);
+    return ScorePair(-p.m_Value);
 }
 
-constexpr PackedScore operator*(int a, const PackedScore& b)
+constexpr ScorePair operator*(int a, const ScorePair& b)
 {
-    return PackedScore(a * b.m_Value);
+    return ScorePair(a * b.m_Value);
 }
 
-constexpr PackedScore operator*(const PackedScore& a, int b)
+constexpr ScorePair operator*(const ScorePair& a, int b)
 {
-    return PackedScore(a.m_Value * b);
+    return ScorePair(a.m_Value * b);
 }

--- a/src/sirius/movegen.cpp
+++ b/src/sirius/movegen.cpp
@@ -1,0 +1,292 @@
+
+#include "movegen.h"
+#include "attacks.h"
+
+template<MoveGenType type, Color color>
+void genMoves(const Board& board, MoveList& moves);
+
+template<MoveGenType type>
+void genMoves(const Board& board, MoveList& moves)
+{
+    if (board.sideToMove() == Color::WHITE)
+    {
+        genMoves<type, Color::WHITE>(board, moves);
+    }
+    else
+    {
+        genMoves<type, Color::BLACK>(board, moves);
+    }
+}
+
+template<>
+void genMoves<MoveGenType::LEGAL>(const Board& board, MoveList& moves)
+{
+    genMoves<MoveGenType::NOISY_QUIET>(board, moves);
+    size_t j = 0;
+    for (size_t i = 0; i < moves.size(); i++)
+    {
+        if (board.isLegal(moves[i]))
+            moves[j++] = moves[i];
+    }
+    moves.resize(j);
+}
+
+template void genMoves<MoveGenType::NOISY>(const Board& board, MoveList& moves);
+template void genMoves<MoveGenType::NOISY_QUIET>(const Board& board, MoveList& moves);
+template void genMoves<MoveGenType::QUIET>(const Board& board, MoveList& moves);
+
+template<MoveGenType type, Color color>
+void genKingMoves(const Board& board, MoveList& moves);
+
+template<MoveGenType type, Color color, PieceType piece>
+void genPieceMoves(const Board& board, MoveList& moves, Bitboard moveMask);
+
+template<MoveGenType type, Color color>
+void genPawnMoves(const Board& board, MoveList& moves, Bitboard moveMask);
+
+template<MoveGenType type, Color color>
+void genMoves(const Board& board, MoveList& moves)
+{
+    Bitboard checkers = board.checkers();
+    if (!checkers.multiple())
+    {
+        Bitboard moveMask = ~board.pieces(color)
+            & (checkers.any() ? attacks::moveMask(board.kingSq(color), checkers.lsb()) : ALL_BB);
+        genPawnMoves<type, color>(board, moves, moveMask);
+        if constexpr (type == MoveGenType::NOISY)
+            moveMask &= board.pieces(~color);
+        else if constexpr (type == MoveGenType::QUIET)
+            moveMask &= ~board.pieces(~color);
+        genPieceMoves<type, color, PieceType::KNIGHT>(board, moves, moveMask);
+        genPieceMoves<type, color, PieceType::BISHOP>(board, moves, moveMask);
+        genPieceMoves<type, color, PieceType::ROOK>(board, moves, moveMask);
+        genPieceMoves<type, color, PieceType::QUEEN>(board, moves, moveMask);
+    }
+    genKingMoves<type, color>(board, moves);
+}
+
+template<MoveGenType type, Color color>
+void genKingMoves(const Board& board, MoveList& moves)
+{
+    Bitboard usBB = board.pieces(color);
+    Bitboard oppBB = board.pieces(~color);
+    Square kingSq = board.kingSq(color);
+
+    Bitboard kingAttacks = attacks::kingAttacks(kingSq);
+    kingAttacks &= ~usBB;
+    if constexpr (type == MoveGenType::NOISY)
+        kingAttacks &= oppBB;
+    else if constexpr (type == MoveGenType::QUIET)
+        kingAttacks &= ~oppBB;
+    while (kingAttacks.any())
+    {
+        Square dst = kingAttacks.poplsb();
+        moves.push_back(Move(kingSq, dst, MoveType::NONE));
+    }
+
+    if constexpr (type == MoveGenType::NOISY_QUIET || type == MoveGenType::QUIET)
+    {
+        if (board.checkers().empty())
+        {
+            CastlingRights kingSide(color, CastleSide::KING_SIDE);
+            CastlingRights queenSide(color, CastleSide::QUEEN_SIDE);
+
+            Square kingSideRook = board.castlingRookSq(color, CastleSide::KING_SIDE);
+            Square queenSideRook = board.castlingRookSq(color, CastleSide::QUEEN_SIDE);
+
+            if (board.castlingRights().has(kingSide)
+                && !board.castlingBlocked(color, CastleSide::KING_SIDE))
+            {
+                moves.push_back(Move(kingSq, kingSideRook, MoveType::CASTLE));
+            }
+
+            if (board.castlingRights().has(queenSide)
+                && !board.castlingBlocked(color, CastleSide::QUEEN_SIDE))
+            {
+                moves.push_back(Move(kingSq, queenSideRook, MoveType::CASTLE));
+            }
+        }
+    }
+}
+
+template<MoveGenType type, Color color, PieceType piece>
+void genPieceMoves(const Board& board, MoveList& moves, Bitboard moveMask)
+{
+    Bitboard pieceBB = board.pieces(color, piece);
+    Bitboard allPieces = board.allPieces();
+
+    while (pieceBB.any())
+    {
+        Square from = pieceBB.poplsb();
+        Bitboard attacks = attacks::pieceAttacks<piece>(from, allPieces) & moveMask;
+        while (attacks.any())
+        {
+            Square to = attacks.poplsb();
+            moves.push_back(Move(from, to, MoveType::NONE));
+        }
+    }
+}
+
+template<MoveGenType type, Color color>
+void genPawnMoves(const Board& board, MoveList& moves, Bitboard moveMask)
+{
+    constexpr int PUSH_OFFSET = attacks::pawnPushOffset<color>();
+
+    Bitboard pawns = board.pieces(color, PieceType::PAWN);
+    Bitboard allPieces = board.allPieces();
+    Bitboard oppBB = board.pieces(~color);
+
+    if constexpr (type == MoveGenType::NOISY_QUIET)
+    {
+        Bitboard pawnPushes = attacks::pawnPushes<color>(pawns);
+        pawnPushes &= ~allPieces;
+
+        Bitboard doublePushes =
+            attacks::pawnPushes<color>(pawnPushes & Bitboard::nthRank<color, RANK_3>());
+        doublePushes &= ~allPieces;
+        doublePushes &= moveMask;
+
+        pawnPushes &= moveMask;
+
+        Bitboard promotions = pawnPushes & Bitboard::nthRank<color, RANK_8>();
+
+        pawnPushes ^= promotions;
+
+        while (pawnPushes.any())
+        {
+            Square push = pawnPushes.poplsb();
+            Square from = push - PUSH_OFFSET;
+            moves.push_back(Move(from, push, MoveType::NONE));
+        }
+
+        while (doublePushes.any())
+        {
+            Square dPush = doublePushes.poplsb();
+            Square from = dPush - 2 * PUSH_OFFSET;
+            moves.push_back(Move(from, dPush, MoveType::NONE));
+        }
+
+        while (promotions.any())
+        {
+            Square promotion = promotions.poplsb();
+            Square from = promotion - PUSH_OFFSET;
+            moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::QUEEN));
+            moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::ROOK));
+            moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::BISHOP));
+            moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::KNIGHT));
+        }
+    }
+    else if constexpr (type == MoveGenType::NOISY)
+    {
+        Bitboard pawnPushes = attacks::pawnPushes<color>(pawns);
+        pawnPushes &= ~allPieces;
+        pawnPushes &= moveMask;
+
+        Bitboard promotions = pawnPushes & Bitboard::nthRank<color, RANK_8>();
+
+        while (promotions.any())
+        {
+            Square promotion = promotions.poplsb();
+            Square from = promotion - PUSH_OFFSET;
+            moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::QUEEN));
+            moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::ROOK));
+            moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::BISHOP));
+            moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::KNIGHT));
+        }
+    }
+    else if constexpr (type == MoveGenType::QUIET)
+    {
+        Bitboard pawnPushes = attacks::pawnPushes<color>(pawns);
+        pawnPushes &= ~allPieces;
+
+        Bitboard doublePushes = attacks::pawnPushes<color>(pawnPushes & Bitboard::nthRank<color, 2>());
+        doublePushes &= ~allPieces;
+        doublePushes &= moveMask;
+
+        pawnPushes &= moveMask;
+
+        Bitboard promotions = pawnPushes & Bitboard::nthRank<color, 7>();
+        pawnPushes ^= promotions;
+
+        while (pawnPushes.any())
+        {
+            Square push = pawnPushes.poplsb();
+            Square from = push - PUSH_OFFSET;
+            moves.push_back(Move(from, push, MoveType::NONE));
+        }
+
+        while (doublePushes.any())
+        {
+            Square dPush = doublePushes.poplsb();
+            Square from = dPush - 2 * PUSH_OFFSET;
+            moves.push_back(Move(from, dPush, MoveType::NONE));
+        }
+
+        // rest of the pawn movegen is captures/promos
+        return;
+    }
+
+    Bitboard eastCaptures = attacks::pawnEastAttacks<color>(pawns);
+    if (board.epSquare() != -1 && eastCaptures.has(Square(board.epSquare()))
+        && moveMask.has(Square(board.epSquare()) - PUSH_OFFSET))
+    {
+        Square to = Square(board.epSquare());
+        Square from = to - PUSH_OFFSET - 1;
+        moves.push_back(Move(from, to, MoveType::ENPASSANT));
+    }
+
+    eastCaptures &= oppBB;
+    eastCaptures &= moveMask;
+
+    Bitboard promotions = eastCaptures & Bitboard::nthRank<color, RANK_8>();
+    eastCaptures ^= promotions;
+
+    while (eastCaptures.any())
+    {
+        Square capture = eastCaptures.poplsb();
+        Square from = capture - PUSH_OFFSET - 1;
+        moves.push_back(Move(from, capture, MoveType::NONE));
+    }
+
+    while (promotions.any())
+    {
+        Square promotion = promotions.poplsb();
+        Square from = promotion - PUSH_OFFSET - 1;
+        moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::QUEEN));
+        moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::ROOK));
+        moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::BISHOP));
+        moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::KNIGHT));
+    }
+
+    Bitboard westCaptures = attacks::pawnWestAttacks<color>(pawns);
+    if (board.epSquare() != -1 && westCaptures.has(Square(board.epSquare()))
+        && moveMask.has(Square(board.epSquare()) - PUSH_OFFSET))
+    {
+        Square to = Square(board.epSquare());
+        Square from = to - PUSH_OFFSET + 1;
+        moves.push_back(Move(from, to, MoveType::ENPASSANT));
+    }
+
+    westCaptures &= oppBB;
+    westCaptures &= moveMask;
+
+    promotions = westCaptures & Bitboard::nthRank<color, RANK_8>();
+    westCaptures ^= promotions;
+
+    while (westCaptures.any())
+    {
+        Square capture = westCaptures.poplsb();
+        Square from = capture - PUSH_OFFSET + 1;
+        moves.push_back(Move(from, capture, MoveType::NONE));
+    }
+
+    while (promotions.any())
+    {
+        Square promotion = promotions.poplsb();
+        Square from = promotion - PUSH_OFFSET + 1;
+        moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::QUEEN));
+        moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::ROOK));
+        moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::BISHOP));
+        moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::KNIGHT));
+    }
+}

--- a/src/sirius/movegen.h
+++ b/src/sirius/movegen.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "board.h"
+#include "util/static_vector.h"
+
+enum class MoveGenType
+{
+    LEGAL,
+    NOISY_QUIET,
+    NOISY,
+    QUIET
+};
+
+using MoveList = StaticVector<Move, 256>;
+
+template<MoveGenType type>
+void genMoves(const Board& board, MoveList& moves);

--- a/src/sirius/util/enum_array.h
+++ b/src/sirius/util/enum_array.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../defs.h"
+#include <array>
 
 template<typename T, typename E, size_t N>
 struct EnumArray : public std::array<T, N>
@@ -23,4 +24,3 @@ using ColorArray = EnumArray<T, Color, 2>;
 
 template<typename T>
 using PieceTypeArray = EnumArray<T, PieceType, 6>;
-

--- a/src/sirius/util/multi_array.h
+++ b/src/sirius/util/multi_array.h
@@ -6,19 +6,20 @@
 // stormphrax yoink
 namespace internal
 {
-    template<typename T, size_t N, size_t ...Ns>
-    struct MultiArrayImpl
-    {
-        using Type = std::array<typename MultiArrayImpl<T, Ns...>::Type, N>;
-    };
 
-    template<typename T, size_t N>
-    struct MultiArrayImpl<T, N>
-    {
-        using Type = std::array<T, N>;
-    };
+template<typename T, size_t N, size_t... Ns>
+struct MultiArrayImpl
+{
+    using Type = std::array<typename MultiArrayImpl<T, Ns...>::Type, N>;
+};
+
+template<typename T, size_t N>
+struct MultiArrayImpl<T, N>
+{
+    using Type = std::array<T, N>;
+};
+
 }
 
-template<typename T, size_t ...Ns>
+template<typename T, size_t... Ns>
 using MultiArray = typename internal::MultiArrayImpl<T, Ns...>::Type;
-

--- a/src/sirius/util/murmur.h
+++ b/src/sirius/util/murmur.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cstdint>
 
 constexpr uint64_t murmurHash3(uint64_t key)
@@ -9,4 +11,3 @@ constexpr uint64_t murmurHash3(uint64_t key)
     key ^= key >> 33;
     return key;
 };
-

--- a/src/sirius/util/prng.h
+++ b/src/sirius/util/prng.h
@@ -10,6 +10,7 @@ public:
     constexpr PRNG() = default;
     constexpr void seed(uint64_t s);
     constexpr uint64_t next64();
+
 private:
     uint64_t a, b, c, counter;
 };

--- a/src/sirius/util/static_vector.h
+++ b/src/sirius/util/static_vector.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstddef>
+
+template<typename T, size_t Capacity>
+class StaticVector
+{
+public:
+    StaticVector() = default;
+
+    void push_back(const T& elem)
+    {
+        assert(m_Size < Capacity);
+        m_Data[m_Size++] = elem;
+    }
+
+    void push_back(T&& elem)
+    {
+        assert(m_Size < Capacity);
+        m_Data[m_Size++] = std::move(elem);
+    }
+
+    void clear()
+    {
+        m_Size = 0;
+    }
+
+    void fill(const T& value)
+    {
+        std::fill(begin(), end(), value);
+    }
+
+    size_t size() const
+    {
+        return m_Size;
+    }
+
+    T* data()
+    {
+        return m_Data.data();
+    }
+
+    const T* data() const
+    {
+        return m_Data.data();
+    }
+
+    auto begin()
+    {
+        return m_Data.begin();
+    }
+
+    auto end()
+    {
+        return begin() + m_Size;
+    }
+
+    auto begin() const
+    {
+        return cbegin();
+    }
+
+    auto end() const
+    {
+        return cend();
+    }
+
+    auto cbegin() const
+    {
+        return m_Data.cbegin();
+    }
+
+    auto cend() const
+    {
+        return cbegin() + m_Size;
+    }
+
+    T& operator[](size_t pos)
+    {
+        assert(pos < m_Size);
+        return m_Data[pos];
+    }
+
+    const T& operator[](size_t pos) const
+    {
+        assert(pos < m_Size);
+        return m_Data[pos];
+    }
+
+    void resize(size_t size)
+    {
+        m_Size = size;
+    }
+
+private:
+    std::array<T, Capacity> m_Data;
+    size_t m_Size = 0;
+};

--- a/src/sirius/util/string_split.h
+++ b/src/sirius/util/string_split.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// https://stackoverflow.com/a/236803
+std::vector<std::string> splitBySpaces(const std::string_view& str)
+{
+    std::istringstream iss{std::string(str)};
+    std::string token;
+    std::vector<std::string> result;
+    while (std::getline(iss, token, ' '))
+    {
+        result.push_back(token);
+    }
+    return result;
+}

--- a/src/sirius/zobrist.h
+++ b/src/sirius/zobrist.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <cstdint>
+#include "castling.h"
 #include "defs.h"
 #include "util/multi_array.h"
 #include "util/prng.h"
+#include <cstdint>
 
 namespace zobrist
 {
@@ -65,17 +66,20 @@ inline void ZKey::flipSideToMove()
 
 inline void ZKey::addPiece(PieceType piece, Color color, Square square)
 {
-    value ^= zobrist::keys.pieceSquares[static_cast<int>(color)][static_cast<int>(piece)][square.value()];
+    value ^=
+        zobrist::keys.pieceSquares[static_cast<int>(color)][static_cast<int>(piece)][square.value()];
 }
 
 inline void ZKey::removePiece(PieceType piece, Color color, Square square)
 {
-    value ^= zobrist::keys.pieceSquares[static_cast<int>(color)][static_cast<int>(piece)][square.value()];
+    value ^=
+        zobrist::keys.pieceSquares[static_cast<int>(color)][static_cast<int>(piece)][square.value()];
 }
 
 inline void ZKey::movePiece(PieceType piece, Color color, Square src, Square dst)
 {
-    value ^= zobrist::keys.pieceSquares[static_cast<int>(color)][static_cast<int>(piece)][src.value()] ^ zobrist::keys.pieceSquares[static_cast<int>(color)][static_cast<int>(piece)][dst.value()];
+    value ^= zobrist::keys.pieceSquares[static_cast<int>(color)][static_cast<int>(piece)][src.value()]
+        ^ zobrist::keys.pieceSquares[static_cast<int>(color)][static_cast<int>(piece)][dst.value()];
 }
 
 inline void ZKey::updateCastlingRights(CastlingRights castlingRights)

--- a/src/thread_pool.h
+++ b/src/thread_pool.h
@@ -1,11 +1,12 @@
 #pragma once
 
-#include <vector>
-#include <thread>
-#include <mutex>
 #include <condition_variable>
 #include <deque>
 #include <functional>
+#include <mutex>
+#include <thread>
+#include <vector>
+
 
 class ThreadPool
 {
@@ -20,6 +21,7 @@ public:
 
     void wait();
     void addTask(const std::function<void()>& task);
+
 private:
     void stop();
     void threadLoop();

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -5,7 +5,6 @@
 #include <chrono>
 #include <iostream>
 
-
 double sigmoid(double x, double k)
 {
     return 1.0 / (1 + exp(-x * k));
@@ -296,29 +295,21 @@ EvalParams tune(const Dataset& dataset, std::ofstream& outFile)
             auto totalTime =
                 std::chrono::duration_cast<std::chrono::duration<double>>(t2 - startTime).count();
             std::cout << "Epochs/s (total): " << static_cast<double>(epoch) / totalTime << std::endl;
-            std::cout << "Epochs/s (avg of last 100): "
-                      << 100.0f
+            std::cout << "Epochs/s (avg of last 10): "
+                      << 10.0f
                     / std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1).count()
                       << std::endl;
             std::cout << "Total time: " << totalTime << std::endl;
             outFile << "Epochs/s (total): " << static_cast<double>(epoch) / totalTime << std::endl;
-            outFile << "Epochs/s (avg of last 100): "
-                    << 100.0f
-                    / std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1).count()
+            outFile << "Epochs/s (avg of last 10): "
+                    << 10.0f / std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1).count()
                     << std::endl;
             outFile << "Total time: " << totalTime << std::endl;
 
             t1 = t2;
             EvalFn::printEvalParams(params, std::cout);
-            std::cout << std::endl; /*
+            std::cout << std::endl;
 
-             EvalParams extracted = params;
-             for (auto& param : extracted)
-             {
-                 param.mg = std::round(param.mg);
-                 param.eg = std::round(param.eg);
-             }*/
-            // EvalFn::printEvalParamsExtracted(extracted, outFile);
             EvalFn::printEvalParamsExtracted(params, outFile);
             outFile << std::endl;
         }

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -1,9 +1,10 @@
 #include "tune.h"
 #include "eval_fn.h"
-#include "thread_pool.h"
 #include "settings.h"
-#include <iostream>
+#include "thread_pool.h"
 #include <chrono>
+#include <iostream>
+
 
 double sigmoid(double x, double k)
 {
@@ -88,7 +89,8 @@ double evaluate(const Position& pos, Coeffs coefficients, const EvalParams& para
     return evaluate(pos, coefficients, params, trace);
 }
 
-double findKValue(ThreadPool& threadPool, std::span<const Position> positions, Coeffs coefficients, const EvalParams& params)
+double findKValue(ThreadPool& threadPool, std::span<const Position> positions, Coeffs coefficients,
+    const EvalParams& params)
 {
     constexpr double SEARCH_MAX = 1;
     constexpr int ITERATIONS = 7;
@@ -99,7 +101,8 @@ double findKValue(ThreadPool& threadPool, std::span<const Position> positions, C
     for (int i = 0; i < ITERATIONS; i++)
     {
         std::cout << "Iteration: " << i << std::endl;
-        std::cout << "Start: " << start + step << " End: " << end + step << " Step: " << step << std::endl;
+        std::cout << "Start: " << start + step << " End: " << end + step << " Step: " << step
+                  << std::endl;
         for (double curr = start + step; curr < end + step; curr += step)
         {
             double error = calcError(threadPool, positions, coefficients, curr, params);
@@ -120,7 +123,8 @@ double findKValue(ThreadPool& threadPool, std::span<const Position> positions, C
     return bestK;
 }
 
-double calcError(ThreadPool& threadPool, std::span<const Position> positions, Coeffs coefficients, double kValue, const EvalParams& params)
+double calcError(ThreadPool& threadPool, std::span<const Position> positions, Coeffs coefficients,
+    double kValue, const EvalParams& params)
 {
     std::vector<double> threadErrors(threadPool.concurrency());
     for (uint32_t threadID = 0; threadID < threadPool.concurrency(); threadID++)
@@ -128,17 +132,18 @@ double calcError(ThreadPool& threadPool, std::span<const Position> positions, Co
         size_t beginIdx = positions.size() * threadID / threadPool.concurrency();
         size_t endIdx = positions.size() * (threadID + 1) / threadPool.concurrency();
         std::span<const Position> threadPositions = positions.subspan(beginIdx, endIdx - beginIdx);
-        threadPool.addTask([threadID, &threadErrors, threadPositions, coefficients, kValue, &params]()
-        {
-            double error = 0.0;
-            for (auto& pos : threadPositions)
+        threadPool.addTask(
+            [threadID, &threadErrors, threadPositions, coefficients, kValue, &params]()
             {
-                double eval = evaluate(pos, coefficients, params);
-                double diff = sigmoid(eval, kValue) - pos.wdl;
-                error += diff * diff;
-            }
-            threadErrors[threadID] = error;
-        });
+                double error = 0.0;
+                for (auto& pos : threadPositions)
+                {
+                    double eval = evaluate(pos, coefficients, params);
+                    double diff = sigmoid(eval, kValue) - pos.wdl;
+                    error += diff * diff;
+                }
+                threadErrors[threadID] = error;
+            });
     }
     threadPool.wait();
     double error = 0.0;
@@ -147,7 +152,8 @@ double calcError(ThreadPool& threadPool, std::span<const Position> positions, Co
     return error / static_cast<double>(positions.size());
 }
 
-void updateGradient(const Position& pos, Coeffs coefficients, double kValue, const EvalParams& params, std::vector<Gradient>& gradients)
+void updateGradient(const Position& pos, Coeffs coefficients, double kValue,
+    const EvalParams& params, std::vector<Gradient>& gradients)
 {
     EvalTrace trace = {};
     double eval = evaluate(pos, coefficients, params, trace);
@@ -170,24 +176,30 @@ void updateGradient(const Position& pos, Coeffs coefficients, double kValue, con
         {
             if (trace.complexity.mg >= -std::abs(trace.nonComplexity.mg))
             {
-                gradients[coeff.index].mg += coeff.white * mgBase * safetyDerivMg(trace.rawSafety[Color::WHITE].mg);
-                gradients[coeff.index].mg -= coeff.black * mgBase * safetyDerivMg(trace.rawSafety[Color::BLACK].mg);
+                gradients[coeff.index].mg +=
+                    coeff.white * mgBase * safetyDerivMg(trace.rawSafety[Color::WHITE].mg);
+                gradients[coeff.index].mg -=
+                    coeff.black * mgBase * safetyDerivMg(trace.rawSafety[Color::BLACK].mg);
             }
             if (trace.complexity.eg >= -std::abs(trace.nonComplexity.eg))
             {
-                gradients[coeff.index].eg += coeff.white * egBase * pos.egScale * safetyDerivEg(trace.rawSafety[Color::WHITE].eg);
-                gradients[coeff.index].eg -= coeff.black * egBase * pos.egScale * safetyDerivEg(trace.rawSafety[Color::BLACK].eg);
+                gradients[coeff.index].eg += coeff.white * egBase * pos.egScale
+                    * safetyDerivEg(trace.rawSafety[Color::WHITE].eg);
+                gradients[coeff.index].eg -= coeff.black * egBase * pos.egScale
+                    * safetyDerivEg(trace.rawSafety[Color::BLACK].eg);
             }
         }
         else if (type == ParamType::COMPLEXITY)
         {
             if (trace.complexity.eg >= -std::abs(trace.nonComplexity.eg))
-                gradients[coeff.index].eg += egBase * coeff.white * pos.egScale * ((trace.normal.eg > 0) - (trace.normal.eg < 0));
+                gradients[coeff.index].eg += egBase * coeff.white * pos.egScale
+                    * ((trace.normal.eg > 0) - (trace.normal.eg < 0));
         }
     }
 }
 
-void computeGradient(ThreadPool& threadPool, std::span<const Position> positions, Coeffs coefficients, double kValue, const EvalParams& params, std::vector<Gradient>& gradients)
+void computeGradient(ThreadPool& threadPool, std::span<const Position> positions,
+    Coeffs coefficients, double kValue, const EvalParams& params, std::vector<Gradient>& gradients)
 {
     std::fill(gradients.begin(), gradients.end(), Gradient{0, 0});
 
@@ -198,11 +210,12 @@ void computeGradient(ThreadPool& threadPool, std::span<const Position> positions
         size_t beginIdx = positions.size() * threadID / threadPool.concurrency();
         size_t endIdx = positions.size() * (threadID + 1) / threadPool.concurrency();
         std::span<const Position> threadPositions = positions.subspan(beginIdx, endIdx - beginIdx);
-        threadPool.addTask([threadID, &threadGradients, threadPositions, coefficients, kValue, &params]()
-        {
-            for (const auto& pos : threadPositions)
-                updateGradient(pos, coefficients, kValue, params, threadGradients[threadID]);
-        });
+        threadPool.addTask(
+            [threadID, &threadGradients, threadPositions, coefficients, kValue, &params]()
+            {
+                for (const auto& pos : threadPositions)
+                    updateGradient(pos, coefficients, kValue, params, threadGradients[threadID]);
+            });
     }
 
     threadPool.wait();
@@ -226,7 +239,9 @@ EvalParams tune(const Dataset& dataset, std::ofstream& outFile)
 {
     ThreadPool threadPool(TUNE_THREADS);
     EvalParams params = EvalFn::getInitialParams();
-    double kValue = TUNE_K <= 0 ? findKValue(threadPool, dataset.positions, dataset.allCoefficients, EvalFn::getKParams()) : TUNE_K;
+    double kValue = TUNE_K <= 0
+        ? findKValue(threadPool, dataset.positions, dataset.allCoefficients, EvalFn::getKParams())
+        : TUNE_K;
     std::cout << "Final k value: " << kValue << std::endl;
     outFile << "Final k value: " << kValue << std::endl;
     if constexpr (TUNE_FROM_ZERO)
@@ -251,11 +266,10 @@ EvalParams tune(const Dataset& dataset, std::ofstream& outFile)
     {
         for (int batch = 0; batch < dataset.positions.size() / BATCH_SIZE; batch++)
         {
-            std::span<const Position> batchPositions = {
-                dataset.positions.begin() + batch * BATCH_SIZE,
-                std::min<size_t>(BATCH_SIZE, dataset.positions.size() - batch * BATCH_SIZE)
-            };
-            computeGradient(threadPool, batchPositions, dataset.allCoefficients, kValue, params, gradient);
+            std::span<const Position> batchPositions = {dataset.positions.begin() + batch * BATCH_SIZE,
+                std::min<size_t>(BATCH_SIZE, dataset.positions.size() - batch * BATCH_SIZE)};
+            computeGradient(
+                threadPool, batchPositions, dataset.allCoefficients, kValue, params, gradient);
 
             for (int i = 0; i < gradient.size(); i++)
             {
@@ -271,32 +285,40 @@ EvalParams tune(const Dataset& dataset, std::ofstream& outFile)
         }
         if (epoch % 10 == 0)
         {
-            double error = calcError(threadPool, dataset.positions, dataset.allCoefficients, kValue, params);
+            double error =
+                calcError(threadPool, dataset.positions, dataset.allCoefficients, kValue, params);
             std::cout << "Epoch: " << epoch << std::endl;
             std::cout << "Error: " << error << std::endl;
             outFile << "Epoch: " << epoch << std::endl;
             outFile << "Error: " << error << std::endl;
 
             auto t2 = std::chrono::steady_clock::now();
-            auto totalTime = std::chrono::duration_cast<std::chrono::duration<double>>(t2 - startTime).count();
+            auto totalTime =
+                std::chrono::duration_cast<std::chrono::duration<double>>(t2 - startTime).count();
             std::cout << "Epochs/s (total): " << static_cast<double>(epoch) / totalTime << std::endl;
-            std::cout << "Epochs/s (avg of last 100): " << 100.0f / std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1).count() << std::endl;
+            std::cout << "Epochs/s (avg of last 100): "
+                      << 100.0f
+                    / std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1).count()
+                      << std::endl;
             std::cout << "Total time: " << totalTime << std::endl;
             outFile << "Epochs/s (total): " << static_cast<double>(epoch) / totalTime << std::endl;
-            outFile << "Epochs/s (avg of last 100): " << 100.0f / std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1).count() << std::endl;
+            outFile << "Epochs/s (avg of last 100): "
+                    << 100.0f
+                    / std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1).count()
+                    << std::endl;
             outFile << "Total time: " << totalTime << std::endl;
 
             t1 = t2;
             EvalFn::printEvalParams(params, std::cout);
-            std::cout << std::endl;/*
+            std::cout << std::endl; /*
 
-            EvalParams extracted = params;
-            for (auto& param : extracted)
-            {
-                param.mg = std::round(param.mg);
-                param.eg = std::round(param.eg);
-            }*/
-            //EvalFn::printEvalParamsExtracted(extracted, outFile);
+             EvalParams extracted = params;
+             for (auto& param : extracted)
+             {
+                 param.mg = std::round(param.mg);
+                 param.eg = std::round(param.eg);
+             }*/
+            // EvalFn::printEvalParamsExtracted(extracted, outFile);
             EvalFn::printEvalParamsExtracted(params, outFile);
             outFile << std::endl;
         }


### PR DESCRIPTION
- Update Sirius
- Make the eval more consistent with how it looks in Sirius
    - Reorder king safety terms
    - Add `using enum PieceType` and `using enum Color`
- Remove some old comments
- Fixed Epochs/s calculation
- Set the right half the king psqt to 0, which is unused because of horizontal mirroring
- Fixed a bugged addCoefficient condition which was slowing things down a lot
- Removed some unused variables